### PR TITLE
EPIC-044 Story 44.11: Projected 12-team playoff bracket

### DIFF
--- a/docs/EPIC-044-TICKER-REDESIGN.md
+++ b/docs/EPIC-044-TICKER-REDESIGN.md
@@ -87,13 +87,19 @@ hooks in `board.js`; backend changes are verified via FastAPI `TestClient`.
 - [x] Win-prob bar split in team brand colors with clash-recolor
 - [x] Mapped to the real `/api/predictions` contract
 
-### Story 44.7: Re-home remaining board features ⬜
-**Not started — needs designs (like the predictions one)**
-- [ ] Postseason results
-- [ ] Prediction-accuracy banner
-- [ ] Legend
-- [ ] Share Top 25 card
+### Story 44.7: Re-home remaining board features 🚧
+**Postseason delivered as the projected bracket (Story 44.11). Rest pending.**
+- [x] ~~Postseason results~~ → superseded by Story 44.11 (Projected Playoff bracket)
+- [ ] Prediction-accuracy banner (planned: ribbon-style tile, no new design)
+- [ ] Legend (shrinks to a small key: OFF/DEF heat, sparkline trend, SOS warn)
+- [ ] Share Top 25 card (reuse `share.js` canvas; Ticker-styled trigger)
 - [ ] Once ported, delete the now-orphaned `js/app.js`
+
+### Story 44.11: Projected playoff bracket ✅
+**Verified** (backend via TestClient, UI via injected projection)
+- [x] `GET /api/playoff-projection` — CFP-style field (conference-champion auto-bids: 4 power + 1 G5 + at-large), straight Elo seeding, seeds 1–4 bye (`project_playoff_bracket` in `ranking_service.py`)
+- [x] Each round simulated with the standard prediction formula (HFA +65 campus / neutral later rounds, scores 30 ± diff/100·3.5)
+- [x] 5-column bracket UI in Ticker style: ▸ advances favored side, win-prob bars, `△ HOST` (campus) / bowl-name (neutral) labels, champion "title favorite" card (`board.js`, `board.css`, `index.html`)
 
 ### Story 44.8: Resolve detail duplication & reskin other pages ⬜
 - [ ] Decide fate of `team.html` (keep vs. redirect to the in-place board detail) and remove duplication

--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -196,6 +196,50 @@
 .tkr-chip2 { display: inline-block; font-family: var(--font-mono); font-size: 10px; font-weight: 600;
   letter-spacing: 0.04em; padding: 3px 8px; border-radius: 6px; background: var(--panel2); color: var(--fg2); }
 
+/* ── Projected playoff bracket ── */
+.tkr-bracket-card { margin-top: 16px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); padding: 18px 20px; }
+.tkr-bracket-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.tkr-bracket-title { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; margin: 0; }
+.tkr-bracket-sub { font-size: 13px; color: var(--fg2); margin: 3px 0 14px; }
+.tkr-bracket-meta { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--fg3);
+  text-transform: uppercase; text-align: right; line-height: 1.6; white-space: nowrap; }
+.bk-cols { display: flex; gap: 14px; min-height: 640px; overflow-x: auto; }
+.bk-col { flex: 1 1 0; min-width: 152px; display: flex; flex-direction: column; }
+.bk-round { border-bottom: 1px solid var(--line); padding-bottom: 8px; margin-bottom: 10px; }
+.bk-round-t { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.05em;
+  text-transform: uppercase; color: var(--fg); }
+.bk-col.champion .bk-round-t { color: var(--accent); }
+.bk-round-d { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.04em; text-transform: uppercase;
+  color: var(--fg3); margin-top: 3px; }
+.bk-col-body { flex: 1; display: flex; flex-direction: column; justify-content: space-around; }
+.bk-col.champion .bk-col-body { justify-content: center; }
+.bk-label { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--fg3); margin-bottom: 5px; }
+.bk-box { border: 1px solid var(--line); border-radius: 8px; background: var(--panel2); padding: 8px 10px; }
+.bk-team { display: flex; align-items: center; gap: 7px; padding: 3px 0; font-family: var(--font-mono); font-size: 12.5px; }
+.bk-team.out { opacity: 0.45; }
+.bk-mk { width: 8px; color: var(--accent); font-size: 10px; }
+.bk-seed { width: 16px; color: var(--fg3); font-size: 11px; text-align: right; }
+.bk-stripe { width: 4px; height: 14px; border-radius: 2px; flex-shrink: 0; }
+.bk-ab { flex: 1; color: var(--fg); font-weight: 600; }
+.bk-team.out .bk-ab { font-weight: 500; }
+.bk-sc { font-weight: 700; color: var(--fg); }
+.bk-bar { height: 4px; border-radius: 3px; overflow: hidden; display: flex; background: var(--line); margin-top: 7px; }
+.bk-bar span { display: block; height: 100%; }
+.bk-pct { display: flex; justify-content: space-between; margin-top: 4px; font-family: var(--font-mono); font-size: 9px; color: var(--fg3); }
+.bk-champ { border: 1px solid var(--accent); border-radius: 12px; background: var(--panel2); padding: 16px; }
+.bk-champ-lbl { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 10px; }
+.bk-champ-name { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 32px;
+  font-weight: 700; color: var(--accent); line-height: 1; }
+.bk-champ-name .bk-stripe { width: 5px; height: 30px; }
+.bk-champ-full { font-size: 15px; font-weight: 700; margin-top: 8px; }
+.bk-champ-sub { font-size: 12px; color: var(--fg2); margin-top: 3px; }
+.bk-champ-win { display: flex; justify-content: space-between; align-items: center; border-top: 1px solid var(--line);
+  margin-top: 14px; padding-top: 10px; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em;
+  text-transform: uppercase; color: var(--fg3); }
+.bk-champ-win .v { color: var(--accent); font-size: 13px; font-weight: 700; }
+
 .hidden { display: none !important; }
 
 @media (max-width: 720px) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,6 +52,18 @@
         </div>
         <div id="tkr-preds-body"></div>
       </div>
+
+      <!-- Projected playoff bracket (rendered by board.js; hidden until loaded) -->
+      <div class="tkr-bracket-card hidden" id="tkr-bracket">
+        <div class="tkr-bracket-head">
+          <div>
+            <h2 class="tkr-bracket-title">Projected Playoff</h2>
+            <p class="tkr-bracket-sub">Model-projected outcome · ▸ marks the favored side advancing.</p>
+          </div>
+          <div class="tkr-bracket-meta">12-TEAM FIELD<br>SEEDS 1–4 BYE</div>
+        </div>
+        <div class="bk-cols" id="tkr-bracket-cols"></div>
+      </div>
     </div>
 
     <!-- Team detail view renders here in place (no route change) -->

--- a/frontend/js/board.js
+++ b/frontend/js/board.js
@@ -273,6 +273,66 @@
     api.getPredictions({ nextWeek: true }).then(renderPredictions).catch(function () {});
   }
 
+  // ── Projected playoff bracket ──
+  var ROUNDS = [
+    { key: 'first_round', t: 'FIRST ROUND', d: 'DEC 19–20 · CAMPUS' },
+    { key: 'quarterfinals', t: 'QUARTERFINALS', d: 'DEC 31 – JAN 1 · BYES ENTER' },
+    { key: 'semifinals', t: 'SEMIFINALS', d: 'JAN 8–9' },
+    { key: 'final', t: 'FINAL', d: 'JAN 19 · LAS VEGAS' },
+  ];
+
+  function bkTeamRow(t, win, color) {
+    return '<div class="bk-team' + (win ? ' win' : ' out') + '">' +
+      '<span class="bk-mk">' + (win ? '▸' : '') + '</span>' +
+      '<span class="bk-seed">' + t.seed + '</span>' +
+      '<span class="bk-stripe" style="background:' + color + '"></span>' +
+      '<span class="bk-ab">' + esc(abbrName(t.name)) + '</span>' +
+      '<span class="bk-sc">' + t.score + '</span></div>';
+  }
+
+  function matchCard(m) {
+    var hi = m.high, lo = m.low, hiWin = m.winner_id === hi.team_id;
+    var hC = stripeName(hi.name), lC = stripeName(lo.name);
+    if (clash(hC, lC)) lC = 'var(--fg3)';
+    var label = m.neutral ? esc(m.label.toUpperCase()) : '△ ' + esc(abbrName(hi.name));
+    return '<div class="bk-card"><div class="bk-label">' + label + '</div>' +
+      '<div class="bk-box">' + bkTeamRow(hi, hiWin, hC) + bkTeamRow(lo, !hiWin, lC) +
+        '<div class="bk-bar"><span style="width:' + Math.round(hi.win_prob) + '%;background:' + hC + '"></span>' +
+          '<span style="width:' + Math.round(lo.win_prob) + '%;background:' + lC + '"></span></div>' +
+        '<div class="bk-pct"><span>' + Math.round(hi.win_prob) + '%</span><span>' + Math.round(lo.win_prob) + '%</span></div>' +
+      '</div></div>';
+  }
+
+  function championCard(ch) {
+    if (!ch) return '';
+    var c = stripeName(ch.name);
+    return '<div class="bk-champ"><div class="bk-champ-lbl">◆ TITLE FAVORITE</div>' +
+      '<div class="bk-champ-name"><span class="bk-stripe" style="background:' + c + '"></span>' + esc(abbrName(ch.name)) + '</div>' +
+      '<div class="bk-champ-full">' + esc(ch.name) + '</div>' +
+      '<div class="bk-champ-sub">No. ' + ch.seed + ' SEED · ' + esc(ch.conference_name || '') + '</div>' +
+      '<div class="bk-champ-win"><span>TITLE-GAME WIN</span><span class="v">' + Math.round(ch.title_game_win_prob) + '%</span></div></div>';
+  }
+
+  function renderBracket(data) {
+    var card = document.getElementById('tkr-bracket');
+    if (!card) return;
+    if (!data || !data.field || !data.field.length) { card.classList.add('hidden'); return; }
+    var cols = ROUNDS.map(function (r) {
+      var items = r.key === 'final' ? (data.final ? [data.final] : []) : (data[r.key] || []);
+      return '<div class="bk-col"><div class="bk-round"><div class="bk-round-t">' + r.t + '</div>' +
+        '<div class="bk-round-d">' + r.d + '</div></div>' +
+        '<div class="bk-col-body">' + items.map(matchCard).join('') + '</div></div>';
+    }).join('');
+    cols += '<div class="bk-col champion"><div class="bk-round"><div class="bk-round-t">CHAMPION</div>' +
+      '<div class="bk-round-d">PROJECTED</div></div><div class="bk-col-body">' + championCard(data.champion) + '</div></div>';
+    document.getElementById('tkr-bracket-cols').innerHTML = cols;
+    card.classList.remove('hidden');
+  }
+
+  function loadBracket() {
+    api.fetch('/playoff-projection').then(renderBracket).catch(function () {});
+  }
+
   // ── Boot ──
   function wireClicks() {
     document.getElementById('tkr-table').addEventListener('click', function (ev) {
@@ -303,6 +363,7 @@
       META = out[0] || {};
       renderAll(out[1]);
       loadPredictions();
+      loadBracket();
     }).catch(function (err) {
       console.error('Board load failed:', err);
       var t = document.getElementById('tkr-table');
@@ -314,6 +375,7 @@
   // (the static preview can't reach the backend — see local-dev memory).
   window.__tkrRender = function (data, meta) { META = meta || META; renderAll(data); };
   window.__tkrRenderPreds = renderPredictions;
+  window.__tkrRenderBracket = renderBracket;
 
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();

--- a/src/api/routers/rankings.py
+++ b/src/api/routers/rankings.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
-from src.core.ranking_service import RankingService
+from src.core.ranking_service import RankingService, project_playoff_bracket
 from src.models import schemas
 from src.models.database import get_db
 from src.models.models import Game, RankingHistory, Season, Team
@@ -285,6 +285,19 @@ async def get_postseason(season: int, db: Session = Depends(get_db)):
             "loser_score": g.away_score if home_won else g.home_score,
         })
     return result
+
+
+@router.get("/api/playoff-projection", tags=["Rankings"])
+async def get_playoff_projection(season: Optional[int] = None, db: Session = Depends(get_db)):
+    """Project the 12-team CFP bracket from current Elo (EPIC-044 Story 44.11).
+
+    CFP-style field selection (conference-champion auto-bids + at-large), straight
+    seeding by Elo, each round simulated with the standard prediction formula.
+    """
+    if not season:
+        active = db.query(Season).filter(Season.is_active == True).first()
+        season = active.year if active else datetime.now().year
+    return project_playoff_bracket(db, season)
 
 
 @router.get(

--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -1202,6 +1202,139 @@ def _calculate_game_prediction(game: Game, home_team: Team, away_team: Team) -> 
     }
 
 
+# ── EPIC-044 Story 44.11: Projected 12-team playoff bracket ──────────────────
+# Bowl labels are fixed to the prototype; in reality the NY6 bowls rotate which
+# rounds they host year to year. ponytail: fixed labels, revisit if rotation matters.
+_QF_BOWLS = ["Rose Bowl", "Sugar Bowl", "Fiesta Bowl", "Peach Bowl"]
+_SF_BOWLS = ["Cotton Bowl", "Orange Bowl"]
+_INDEPENDENT_CONFS = {None, "", "Independent", "Independents", "FBS Independents"}
+
+
+def _project_matchup(high: dict, low: dict, neutral: bool, label: str) -> dict:
+    """Simulate one playoff game. `high` is the higher seed (hosts unless neutral).
+
+    Mirrors _calculate_game_prediction exactly: +65 home-field unless neutral,
+    400-scale logistic win prob, scores = 30 ± (rating_diff / 100) * 3.5.
+    """
+    home_elo = high["elo"] + (0 if neutral else 65)
+    away_elo = low["elo"]
+    home_wp = 1 / (1 + 10 ** ((away_elo - home_elo) / 400))
+    adj = ((home_elo - away_elo) / 100) * 3.5
+    hs = max(0, min(round(30 + adj), 150))
+    ls = max(0, min(round(30 - adj), 150))
+    high_side = {"seed": high["seed"], "team_id": high["team_id"], "name": high["name"],
+                 "elo": high["elo"], "score": hs, "win_prob": round(home_wp * 100, 1)}
+    low_side = {"seed": low["seed"], "team_id": low["team_id"], "name": low["name"],
+                "elo": low["elo"], "score": ls, "win_prob": round((1 - home_wp) * 100, 1)}
+    winner = high_side if home_wp >= 0.5 else low_side
+    return {"label": label, "neutral": neutral, "high": high_side, "low": low_side,
+            "winner_id": winner["team_id"], "winner_seed": winner["seed"]}
+
+
+def _winner_of(m: dict) -> dict:
+    return m["high"] if m["winner_id"] == m["high"]["team_id"] else m["low"]
+
+
+def _sim(a: dict, b: dict, neutral: bool, label: str) -> dict:
+    high, low = (a, b) if a["seed"] < b["seed"] else (b, a)
+    return _project_matchup(high, low, neutral, label)
+
+
+def project_playoff_bracket(db: Session, season: int) -> dict:
+    """Project the 12-team CFP bracket from current Elo (EPIC-044 Story 44.11).
+
+    Field selection (CFP-style): each conference's highest-Elo team is its
+    projected champion; the 4 highest-Elo power (P5) champions plus the single
+    highest-Elo Group-of-5 champion get auto-bids; the field is filled to 12 with
+    the highest-Elo remaining teams as at-large. All 12 are then seeded strictly
+    by Elo (straight seeding); seeds 1–4 get first-round byes.
+    """
+    svc = RankingService(db)
+    rankings = svc.get_current_rankings(season, limit=60)
+    if len(rankings) < 12:
+        return {"season": season, "field": [], "first_round": [], "quarterfinals": [],
+                "semifinals": [], "final": None, "champion": None}
+
+    by_id = {r["team_id"]: r for r in rankings}
+
+    # Projected conference champions = top-Elo team per conference (excl. independents/FCS).
+    champ_by_conf: dict = {}
+    for r in rankings:
+        conf = r.get("conference_name")
+        if conf in _INDEPENDENT_CONFS or r.get("conference") == "FCS":
+            continue
+        cur = champ_by_conf.get(conf)
+        if cur is None or r["elo_rating"] > cur["elo_rating"]:
+            champ_by_conf[conf] = r
+    champs = list(champ_by_conf.values())
+    power_champs = sorted([c for c in champs if c.get("conference") in ("P5", "P4")],
+                          key=lambda c: c["elo_rating"], reverse=True)
+    g5_champs = sorted([c for c in champs if c.get("conference") == "G5"],
+                       key=lambda c: c["elo_rating"], reverse=True)
+
+    auto = power_champs[:4] + g5_champs[:1]
+    if len(auto) < 5:  # backfill if a tier is short
+        for c in sorted(champs, key=lambda c: c["elo_rating"], reverse=True):
+            if c not in auto:
+                auto.append(c)
+            if len(auto) >= 5:
+                break
+    auto_ids = {c["team_id"] for c in auto}
+
+    field = list(auto)
+    for r in rankings:  # at-large by Elo
+        if len(field) >= 12:
+            break
+        if r["team_id"] not in auto_ids:
+            field.append(r)
+
+    field.sort(key=lambda r: r["elo_rating"], reverse=True)
+    champ_ids = {c["team_id"] for c in champs}
+    seeded = []
+    for i, r in enumerate(field[:12]):
+        seeded.append({
+            "seed": i + 1, "team_id": r["team_id"], "name": r["team_name"],
+            "elo": r["elo_rating"], "conference_name": r.get("conference_name"),
+            "is_champ": r["team_id"] in champ_ids, "auto_bid": r["team_id"] in auto_ids,
+        })
+    s = {t["seed"]: t for t in seeded}  # seed → team
+
+    # First round (seeds 5–12 host higher seed, on campus → not neutral).
+    fr = [
+        _sim(s[8], s[9], False, s[8]["name"]),
+        _sim(s[5], s[12], False, s[5]["name"]),
+        _sim(s[7], s[10], False, s[7]["name"]),
+        _sim(s[6], s[11], False, s[6]["name"]),
+    ]
+    # Quarterfinals (neutral): byes enter vs first-round winners.
+    qf = [
+        _sim(s[1], _winner_of(fr[0]), True, _QF_BOWLS[0]),
+        _sim(s[4], _winner_of(fr[1]), True, _QF_BOWLS[1]),
+        _sim(s[2], _winner_of(fr[2]), True, _QF_BOWLS[2]),
+        _sim(s[3], _winner_of(fr[3]), True, _QF_BOWLS[3]),
+    ]
+    sf = [
+        _sim(_winner_of(qf[0]), _winner_of(qf[1]), True, _SF_BOWLS[0]),
+        _sim(_winner_of(qf[2]), _winner_of(qf[3]), True, _SF_BOWLS[1]),
+    ]
+    final = _sim(_winner_of(sf[0]), _winner_of(sf[1]), True, "CFP Championship")
+    champ = _winner_of(final)
+
+    return {
+        "season": season,
+        "field": seeded,
+        "first_round": fr,
+        "quarterfinals": qf,
+        "semifinals": sf,
+        "final": final,
+        "champion": {
+            "seed": champ["seed"], "team_id": champ["team_id"], "name": champ["name"],
+            "conference_name": s[champ["seed"]]["conference_name"],
+            "title_game_win_prob": champ["win_prob"],
+        },
+    }
+
+
 def create_and_store_prediction(db: Session, game: Game) -> Optional[Prediction]:
     """
     Create and store a prediction for a future game.


### PR DESCRIPTION
Adds the projected CFP bracket from the design.

**Backend** — `GET /api/playoff-projection` (`project_playoff_bracket` in ranking_service.py):
- CFP-style field: per-conference champions, 4 power + 1 G5 auto-bid, rest at-large
- Straight Elo seeding, seeds 1–4 bye
- Each round simulated with the standard prediction formula (HFA +65 campus / neutral later; scores 30 ± diff/100·3.5)
- Verified via TestClient on 2025 data (JMU auto-bids as G5 champ; champion OSU 53.1%)

**Frontend** — 5-column bracket in Ticker style (board.js/board.css/index.html): ▸ advances favored side, win-prob bars, △HOST/bowl labels, accent champion card.

Part of EPIC-044. Remaining in Story 44.7: accuracy banner, legend, share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)