### PR TITLE
fix: pass SEASON across the sudo boundary in finalize_2026_preseason.sh

### DIFF
--- a/utilities/finalize_2026_preseason.sh
+++ b/utilities/finalize_2026_preseason.sh
@@ -12,7 +12,9 @@
 
 set -e
 export SEASON="${1:-2026}"
-PYTHON="${CFB_PYTHON:-sudo -u www-data venv/bin/python}"
+# sudo scrubs the environment, so SEASON has to be handed across explicitly.
+# The export above covers the CFB_PYTHON override case (no sudo involved).
+PYTHON="${CFB_PYTHON:-sudo -u www-data SEASON=$SEASON venv/bin/python}"
 cd "${CFB_ROOT:-/var/www/cfb-rankings}"
 
 echo "============================================================"


### PR DESCRIPTION
Follow-up to #8, found while running the EPIC-033 Story 33.2 pipeline against production.

The script exported `SEASON`, but its default interpreter is `sudo -u www-data venv/bin/python`, and sudo scrubs the environment. Every embedded Python block died immediately:

```
[Check] Verifying player data...
Traceback (most recent call last):
  File "<stdin>", line 6, in <module>
KeyError: 'SEASON'
```

The local rehearsal used the `CFB_PYTHON` override, which involves no sudo and passes the export through untouched — so the path that was tested and the path that shipped were different paths. The fix names `SEASON` in the sudo invocation itself; the `export` stays for the override case.

Production was unblocked in the meantime with `CFB_PYTHON="sudo -u www-data SEASON=2026 venv/bin/python"`, which is exactly what this change bakes in as the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)