### PR TITLE
feat: kickoff countdown in the ticker header

### DIFF
--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -27,6 +27,13 @@
 .tkr-wordmark { font-family: var(--font-mono); font-weight: 700; font-size: 14px; color: var(--fg); }
 .tkr-wordmark .dot { color: var(--accent); }
 .tkr-week { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg3); margin-left: 4px; }
+.tkr-countdown {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--accent);
+  margin-left: 8px; white-space: nowrap;
+  /* Digits change every second — fixed advance stops the header jittering. */
+  font-variant-numeric: tabular-nums;
+}
+@media (max-width: 700px) { .tkr-countdown { display: none; } }
 .tkr-header-right { display: flex; align-items: center; gap: 18px; min-width: 0; }
 .tkr-nav { display: flex; gap: 14px; min-width: 0; overflow: hidden; }
 /* Theme pill must always stay reachable — never let the nav squeeze it off-screen */

--- a/frontend/games.html
+++ b/frontend/games.html
@@ -155,6 +155,7 @@
   <script src="js/api.js"></script>
   <script src="js/date-utils.js"></script>
   <script src="js/season.js"></script>
+  <script src="js/countdown.js"></script>
   <script>
     let allGames = [];
     let teams = {};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,5 +74,6 @@
   <!-- Scripts -->
   <script src="js/api.js"></script>
   <script src="js/board.js"></script>
+  <script src="js/countdown.js"></script>
 </body>
 </html>

--- a/frontend/js/countdown.js
+++ b/frontend/js/countdown.js
@@ -1,0 +1,109 @@
+// Countdown to the next kickoff, rendered into #tkr-countdown in the ticker header.
+// Before Week 1 this reads as the countdown to the season opener; once games are
+// underway it tracks the next scheduled game.
+(function () {
+  var TICK_MS = 1000;
+  var el = null;
+  var target = null;   // Date of the next kickoff
+  var label = '';
+  var timer = null;
+
+  var base = (typeof API_BASE_URL !== 'undefined') ? API_BASE_URL : '/api';
+
+  // game_date is stored UTC-naive and serialized without an offset
+  // ("2026-08-29T16:00:00"). JS parses offset-less date-time strings as LOCAL
+  // time, which would skew the countdown by the viewer's UTC offset.
+  function parseUtc(s) {
+    if (!s) return null;
+    var iso = /(Z|[+-]\d{2}:?\d{2})$/.test(s) ? s : s + 'Z';
+    var d = new Date(iso.replace(' ', 'T'));
+    return isNaN(d.getTime()) ? null : d;
+  }
+
+  function pad(n) { return n < 10 ? '0' + n : String(n); }
+
+  function render() {
+    if (!el || !target) return;
+    var ms = target.getTime() - Date.now();
+
+    if (ms <= 0) {
+      el.textContent = 'KICKOFF';
+      clearInterval(timer);
+      timer = null;
+      // Game has started — roll forward to the next one shortly.
+      setTimeout(load, 60000);
+      return;
+    }
+
+    var s = Math.floor(ms / 1000);
+    var d = Math.floor(s / 86400);
+    var h = Math.floor((s % 86400) / 3600);
+    var m = Math.floor((s % 3600) / 60);
+    var sec = s % 60;
+    el.textContent = label + ' ' + (d > 0 ? d + 'd ' : '') + pad(h) + ':' + pad(m) + ':' + pad(sec);
+  }
+
+  function pickNext(games) {
+    var now = Date.now();
+    var soonest = null;
+    for (var i = 0; i < games.length; i++) {
+      var g = games[i];
+      if (g.is_processed) continue;
+      var when = parseUtc(g.game_date);
+      if (!when || when.getTime() <= now) continue;
+      if (!soonest || when < soonest.when) soonest = { when: when, week: g.week };
+    }
+    return soonest;
+  }
+
+  function load() {
+    fetch(base + '/seasons/active')
+      .then(function (r) { return r.json(); })
+      .then(function (season) {
+        var wk = season.current_week != null ? season.current_week : 1;
+        // ponytail: current week + the next one is enough to find the next
+        // kickoff. Widen the range if a bye or a gap ever leaves both empty.
+        var weeks = [wk, wk + 1];
+        return Promise.all(weeks.map(function (w) {
+          return fetch(base + '/games?season=' + season.year + '&week=' + w + '&limit=500')
+            .then(function (r) { return r.json(); })
+            .catch(function () { return []; });
+        })).then(function (lists) {
+          var games = [];
+          for (var i = 0; i < lists.length; i++) {
+            if (Array.isArray(lists[i])) games = games.concat(lists[i]);
+          }
+          return { season: season, next: pickNext(games) };
+        });
+      })
+      .then(function (res) {
+        if (!res.next) { if (el) el.textContent = ''; return; }
+        target = res.next.when;
+        var notStarted = (res.season.current_week == null || res.season.current_week <= 1);
+        label = (notStarted && res.next.week <= 1) ? 'KICKOFF IN' : 'NEXT GAME IN';
+        render();
+        if (!timer) timer = setInterval(render, TICK_MS);
+      })
+      .catch(function (e) {
+        console.warn('Countdown unavailable:', e);
+        if (el) el.textContent = '';
+      });
+  }
+
+  function start() {
+    el = document.getElementById('tkr-countdown');
+    if (el) load();
+  }
+
+  // Expose the two pure helpers so the node self-check can exercise them.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { parseUtc: parseUtc, pickNext: pickNext };
+  }
+  if (typeof document === 'undefined') return;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/frontend/js/layout.js
+++ b/frontend/js/layout.js
@@ -43,6 +43,7 @@
           '<span class="tkr-badge">S</span>' +
           '<span class="tkr-wordmark">STATURDAY<span class="dot">.TKR</span></span>' +
           '<span class="tkr-week" id="tkr-week"></span>' +
+          '<span class="tkr-countdown" id="tkr-countdown"></span>' +
         '</div>' +
         '<div class="tkr-header-right">' +
           '<nav class="tkr-nav">' + navLinks + '</nav>' +

--- a/tests/frontend/test_countdown.js
+++ b/tests/frontend/test_countdown.js
@@ -1,0 +1,69 @@
+// Self-check for the kickoff countdown helpers.
+//   node tests/frontend/test_countdown.js
+//
+// Covers the two things that can silently go wrong: timezone handling on
+// offset-less game_date strings, and picking the right game out of the list.
+
+const assert = require('assert');
+const { parseUtc, pickNext } = require('../../frontend/js/countdown.js');
+
+// game_date arrives UTC-naive. Parsing it as local time would skew the
+// countdown by the viewer's offset, so it must be read as UTC.
+assert.strictEqual(
+  parseUtc('2026-08-29T16:00:00').toISOString(),
+  '2026-08-29T16:00:00.000Z',
+  'offset-less datetime must be read as UTC'
+);
+
+// SQLite hands back a space separator rather than "T".
+assert.strictEqual(
+  parseUtc('2026-08-29 16:00:00.000000').toISOString(),
+  '2026-08-29T16:00:00.000Z',
+  'space-separated datetime must parse'
+);
+
+// An explicit offset must be honoured, not double-applied.
+assert.strictEqual(
+  parseUtc('2026-08-29T12:00:00-04:00').toISOString(),
+  '2026-08-29T16:00:00.000Z',
+  'explicit offset must be preserved'
+);
+
+assert.strictEqual(parseUtc(null), null, 'null date yields null');
+assert.strictEqual(parseUtc('not a date'), null, 'garbage date yields null');
+
+// pickNext: soonest future unplayed game wins, regardless of list order.
+const future = (mins) => new Date(Date.now() + mins * 60000)
+  .toISOString().replace('Z', '');
+const past = (mins) => new Date(Date.now() - mins * 60000)
+  .toISOString().replace('Z', '');
+
+const picked = pickNext([
+  { game_date: future(500), is_processed: false, week: 2 },
+  { game_date: future(10), is_processed: false, week: 1 },
+  { game_date: future(90), is_processed: false, week: 1 },
+]);
+assert.strictEqual(picked.week, 1, 'soonest game wins');
+assert.ok(picked.when.getTime() - Date.now() < 11 * 60000, 'picked the 10-minute game');
+
+// Completed games and games already kicked off are skipped.
+assert.strictEqual(
+  pickNext([
+    { game_date: past(30), is_processed: false, week: 1 },
+    { game_date: future(60), is_processed: true, week: 1 },
+    { game_date: future(120), is_processed: false, week: 1 },
+  ]).when.getTime() - Date.now() > 119 * 60000,
+  true,
+  'past and processed games are skipped'
+);
+
+// Games without a date (TBD) must not crash the pick.
+assert.strictEqual(
+  pickNext([{ game_date: null, is_processed: false, week: 1 }]),
+  null,
+  'all-TBD list yields no target'
+);
+
+assert.strictEqual(pickNext([]), null, 'empty list yields no target');
+
+console.log('countdown self-check passed');


### PR DESCRIPTION
Adds a live countdown to the next scheduled game in the ticker header, beside the week label.

Before Week 1 it reads `KICKOFF IN 23d 02:02:57`; once the season is underway the label becomes `NEXT GAME IN`. Hidden below 700px where the header has no room.

## No backend change

Reads the existing `/api/seasons/active` and `/api/games` endpoints — fetches the current week plus the next one and takes the soonest unplayed game that has a date. No new endpoint, no new dependency, no build step.

## Timezone

`game_date` is stored UTC-naive and serialized without an offset (`"2026-08-29T16:00:00"`). JavaScript parses offset-less date-time strings as **local** time, so a naive `new Date()` would skew the countdown by the viewer's UTC offset — four hours in ET. `parseUtc()` normalizes before comparing.

`frontend/js/date-utils.js` has the same exposure in `formatGameDate()`. Left alone here: it only shifts displayed day labels in edge cases, not a live ticking timer. Worth a separate look.

## Verification

```
$ node tests/frontend/test_countdown.js
countdown self-check passed
```

Dependency-free node self-check covering UTC parsing (offset-less, space-separated, explicit-offset, null, garbage) and game selection (soonest wins, processed and past games skipped, all-TBD and empty lists).

Also run end-to-end against a real `/api/games?season=2026&week=1` payload (99 games): resolves to 2026-08-29 12:00 PM ET, the Week 1 opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)