### PR TITLE
fix: weekly snapshots were overwriting all prior ranking history

### DIFF
--- a/src/api/routers/admin.py
+++ b/src/api/routers/admin.py
@@ -1066,19 +1066,25 @@ async def trigger_import(
                 logger.warning(f"Error processing game {g.id}: {e}")
                 db.rollback()
 
-        # ── Step 3: Save weekly snapshots ─────────────────────────────────
-        from sqlalchemy import text as sa_text
-        weeks_done = db.execute(sa_text(
-            f"SELECT DISTINCT week FROM games WHERE season={season} AND is_processed=1 ORDER BY week"
-        )).fetchall()
+        # ── Step 3: Snapshot the week that just completed ──────────────────
+        # Only the latest week. save_weekly_rankings() writes the CURRENT
+        # teams-table ratings under the week it is given, so looping it over
+        # every completed week overwrites all prior snapshots with today's
+        # numbers and flattens the recorded history.
+        if games_processed:
+            from sqlalchemy import text as sa_text
+            row = db.execute(sa_text(
+                f"SELECT MAX(week) FROM games WHERE season={season} AND is_processed=1"
+            )).fetchone()
+            latest_week = row[0] if row else None
 
-        for (wk,) in weeks_done:
-            try:
-                rs.save_weekly_rankings(season=season, week=wk)
-                db.commit()
-                snapshots_saved += 1
-            except Exception as e:
-                logger.warning(f"Error saving snapshot for week {wk}: {e}")
+            if latest_week is not None:
+                try:
+                    rs.save_weekly_rankings(season=season, week=latest_week)
+                    db.commit()
+                    snapshots_saved += 1
+                except Exception as e:
+                    logger.warning(f"Error saving snapshot for week {latest_week}: {e}")
 
         log_lines.append(f"Games processed: {games_processed}, snapshots: {snapshots_saved}")
 

--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -906,6 +906,12 @@ class RankingService:
         this method needs to build rankings from the teams table (current ELO state) instead
         of calling get_current_rankings() which would create circular logic.
 
+        WARNING: this writes whatever the teams table holds *right now* under the
+        given week, replacing any existing rows for that season/week. It is only
+        correct for the week that just finished processing. Calling it in a loop
+        over past weeks stamps today's ratings across all of history and destroys
+        the real week-by-week record — see tests/unit/test_weekly_snapshot.py.
+
         Args:
             season: Season year
             week: Week number

--- a/src/importers/pipeline.py
+++ b/src/importers/pipeline.py
@@ -238,11 +238,16 @@ Examples:
     season_obj.current_week = final_week
     db.commit()
 
-    # Save rankings through actual max week (including championship week if present)
-    print(f"\nSaving final rankings through Week {final_week}...")
+    # Snapshot ONLY the latest week. save_weekly_rankings() writes the CURRENT
+    # teams-table ratings under the week it is given, so looping it from week 1
+    # stamps end-of-import ratings across every prior week — destroying the real
+    # week-by-week history this table exists to hold.
+    # ponytail: a full rebuild therefore records just the final week. Snapshot
+    # inside the per-week processing loop in games.py if intermediate weeks of a
+    # rebuilt season ever need to be accurate.
+    print(f"\nSaving final rankings for Week {final_week}...")
     # ranking_service already created above for conference championships
-    for week in range(1, final_week + 1):
-        ranking_service.save_weekly_rankings(season, week)
+    ranking_service.save_weekly_rankings(season, final_week)
 
     # Show final rankings
     print("\n" + "=" * 80)

--- a/tests/unit/test_weekly_snapshot.py
+++ b/tests/unit/test_weekly_snapshot.py
@@ -1,0 +1,110 @@
+"""Regression tests for weekly ranking snapshots.
+
+save_weekly_rankings() writes the CURRENT teams-table ratings under the week it
+is given. Three call sites used to loop it over every completed week, which
+overwrote all prior snapshots with today's numbers and flattened the recorded
+history — rank movement went to zero and the team ELO charts became straight
+lines. These tests pin down that behaviour so the loop cannot come back.
+"""
+
+import pytest
+
+from src.core.ranking_service import RankingService
+from src.models.models import ConferenceType, RankingHistory, Team
+
+
+@pytest.fixture
+def teams(test_db):
+    """Three FBS teams with distinct ratings."""
+    created = []
+    for name, elo in [("Alpha", 1800.0), ("Bravo", 1700.0), ("Charlie", 1600.0)]:
+        team = Team(
+            name=name,
+            conference=ConferenceType.POWER_5,
+            conference_name="Test",
+            is_fcs=False,
+            elo_rating=elo,
+        )
+        test_db.add(team)
+        created.append(team)
+    test_db.commit()
+    return created
+
+
+def _ratings_for(db, season, week):
+    """Return {team_id: elo} recorded for a season/week."""
+    rows = db.query(RankingHistory).filter(
+        RankingHistory.season == season, RankingHistory.week == week
+    ).all()
+    return {r.team_id: r.elo_rating for r in rows}
+
+
+def test_snapshot_records_current_team_ratings(test_db, teams):
+    """A snapshot captures the teams table as it stands at call time."""
+    rs = RankingService(test_db)
+    rs.save_weekly_rankings(season=2026, week=1)
+    test_db.commit()
+
+    recorded = _ratings_for(test_db, 2026, 1)
+    assert recorded[teams[0].id] == 1800.0
+    assert recorded[teams[1].id] == 1700.0
+
+
+def test_resnapshotting_a_past_week_overwrites_it(test_db, teams):
+    """The hazard itself: re-snapshotting an old week rewrites it with today's
+    ratings. This is why call sites must only ever snapshot the current week."""
+    rs = RankingService(test_db)
+
+    rs.save_weekly_rankings(season=2026, week=1)
+    test_db.commit()
+    week1_original = _ratings_for(test_db, 2026, 1)
+
+    # Ratings move as the season progresses.
+    teams[0].elo_rating = 1500.0
+    teams[2].elo_rating = 1900.0
+    test_db.commit()
+
+    rs.save_weekly_rankings(season=2026, week=1)
+    test_db.commit()
+    week1_now = _ratings_for(test_db, 2026, 1)
+
+    assert week1_now != week1_original
+    assert week1_now[teams[0].id] == 1500.0, "past week was rewritten with current ratings"
+
+
+def test_snapshotting_current_week_leaves_history_intact(test_db, teams):
+    """The fixed behaviour: snapshot only the latest week and earlier weeks keep
+    the ratings that were true at the time."""
+    rs = RankingService(test_db)
+
+    rs.save_weekly_rankings(season=2026, week=1)
+    test_db.commit()
+    week1_original = _ratings_for(test_db, 2026, 1)
+
+    teams[0].elo_rating = 1500.0
+    teams[2].elo_rating = 1900.0
+    test_db.commit()
+
+    rs.save_weekly_rankings(season=2026, week=2)
+    test_db.commit()
+
+    assert _ratings_for(test_db, 2026, 1) == week1_original, "week 1 must not change"
+    assert _ratings_for(test_db, 2026, 2)[teams[2].id] == 1900.0
+
+    # And the two weeks must actually differ — that difference is what rank
+    # movement and the ELO charts are computed from.
+    assert _ratings_for(test_db, 2026, 1) != _ratings_for(test_db, 2026, 2)
+
+
+def test_snapshot_is_idempotent_within_a_week(test_db, teams):
+    """Re-running the weekly update the same day must not duplicate rows."""
+    rs = RankingService(test_db)
+    rs.save_weekly_rankings(season=2026, week=3)
+    test_db.commit()
+    rs.save_weekly_rankings(season=2026, week=3)
+    test_db.commit()
+
+    rows = test_db.query(RankingHistory).filter(
+        RankingHistory.season == 2026, RankingHistory.week == 3
+    ).all()
+    assert len(rows) == len(teams)

--- a/utilities/weekly_update.sh
+++ b/utilities/weekly_update.sh
@@ -50,6 +50,33 @@ if [ -f "$PROJECT_DIR/.env" ]; then
     set +a
 fi
 
+# ── Notification helper ───────────────────────────────────────────────────────
+# Defined before first use: the CFBD_API_KEY and active-season checks below both
+# call it, and a bash function is not callable until its definition has run.
+_send_notification() {
+    local title="$1"
+    local body="$2"
+
+    # Slack webhook
+    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+        curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            --data "{\"text\":\"$title\n$body\"}" \
+            --max-time 10 \
+            && echo "✓ Slack notification sent" \
+            || echo "⚠ Slack notification failed (continuing)"
+    fi
+
+    # Email fallback
+    if [ -n "${NOTIFY_EMAIL:-}" ]; then
+        if command -v mail &>/dev/null; then
+            echo "$body" | mail -s "$title" "$NOTIFY_EMAIL" \
+                && echo "✓ Email notification sent to $NOTIFY_EMAIL" \
+                || echo "⚠ Email notification failed (continuing)"
+        fi
+    fi
+}
+
 if [ -z "${CFBD_API_KEY:-}" ]; then
     echo "✗ ERROR: CFBD_API_KEY not set. Aborting."
     _send_notification "❌ Weekly update FAILED" "CFBD_API_KEY is not set on the server."
@@ -74,34 +101,6 @@ if [ "$SEASON" = "0" ]; then
     exit 1
 fi
 echo "✓ Active season: $SEASON"
-
-# ── Notification helper ───────────────────────────────────────────────────────
-_send_notification() {
-    local title="$1"
-    local body="$2"
-
-    # Slack webhook
-    if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-        local payload
-        payload=$(printf '{"text":"%s\\n%s"}' "$title" "$body" | sed 's/"/\\"/g')
-        # Build clean JSON directly
-        curl -s -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            --data "{\"text\":\"$title\n$body\"}" \
-            --max-time 10 \
-            && echo "✓ Slack notification sent" \
-            || echo "⚠ Slack notification failed (continuing)"
-    fi
-
-    # Email fallback
-    if [ -n "${NOTIFY_EMAIL:-}" ]; then
-        if command -v mail &>/dev/null; then
-            echo "$body" | mail -s "$title" "$NOTIFY_EMAIL" \
-                && echo "✓ Email notification sent to $NOTIFY_EMAIL" \
-                || echo "⚠ Email notification failed (continuing)"
-        fi
-    fi
-}
 
 # ── Step 1: Import latest schedule + results (with retry) ────────────────────
 echo ""
@@ -177,18 +176,24 @@ for game in unprocessed:
 
 print(f"DONE:{processed_count}")
 
-from sqlalchemy import text
-weeks = db.execute(text(
-    f"SELECT DISTINCT week FROM games WHERE season={season} AND is_processed=1 ORDER BY week"
-)).fetchall()
+# Snapshot ONLY the week that just completed. save_weekly_rankings() writes the
+# CURRENT teams-table ratings under the week you name, so looping it over every
+# completed week stamps today's ratings across all of history — flattening the
+# rank movement and ELO charts. Past weeks are already recorded; leave them.
+if processed_count:
+    from sqlalchemy import text
+    row = db.execute(text(
+        f"SELECT MAX(week) FROM games WHERE season={season} AND is_processed=1"
+    )).fetchone()
+    latest_week = row[0] if row else None
 
-for (week,) in weeks:
-    try:
-        rs.save_weekly_rankings(season=season, week=week)
-        db.commit()
-        print(f"SNAPSHOT:{week}")
-    except Exception as e:
-        print(f"ERROR_SNAPSHOT:{week}:{e}")
+    if latest_week is not None:
+        try:
+            rs.save_weekly_rankings(season=season, week=latest_week)
+            db.commit()
+            print(f"SNAPSHOT:{latest_week}")
+        except Exception as e:
+            print(f"ERROR_SNAPSHOT:{latest_week}:{e}")
 
 db.close()
 EOF


### PR DESCRIPTION
Found while doing the EPIC-033 Story 33.3 task that was never done: *"test the script manually against Week 1 results before going live."*

## The bug

`save_weekly_rankings()` writes whatever the `teams` table holds **right now** under the week it is given, replacing existing rows for that season/week (`src/core/ranking_service.py:901-919`). Three call sites looped it over every completed week.

Reproduced against a copy of the dev database — ran the weekly update's ELO step with 2025 as the active season:

| | Before | After |
|---|---|---|
| 2025 week 14 #1 | Ohio State 1950.4 | Ole Miss 1696.0 |
| 2025 week 14 #2 | Georgia 1928.7 | Georgia 1687.1 |
| weeks in history | 14, 20 | 1–16, 20 — all identical |

All sixteen weeks were rewritten with the `teams` table's then-current 2026 preseason values. It did this having processed **zero** games.

Consequence in the UI: rank movement is computed from the diff between consecutive weekly snapshots, so it goes to zero, and the per-team ELO charts flatten. The damage isn't recoverable without replaying the season.

The cron fires `0 9 * * 1`. First live Monday is Aug 31.

## Fix

Snapshot only the week that just completed, at all three sites:

- `utilities/weekly_update.sh` — plus skip entirely when nothing processed
- `src/api/routers/admin.py` — the reprocess endpoint
- `src/importers/pipeline.py` — this one ran the loop on **every** `import_real_data.py` invocation, including the Story 33.2 production run earlier today (harmless there: `final_week` was 1)

Also moved `_send_notification()` above its first use in `weekly_update.sh`. The `CFBD_API_KEY` and active-season guards both called it before it was defined, so the two failure paths that most need to alert someone died with `command not found` and sent nothing.

A full rebuild now records only the final week instead of fabricating intermediate ones. Where to snapshot per-week, if accurate rebuilt history is ever wanted, is noted in `pipeline.py`.

## Verification

Same scenario, fixed code: 66 games processed, exactly one snapshot written (week 16), weeks 14 and 20 untouched at 1950.4 and 1965.4.

`tests/unit/test_weekly_snapshot.py` pins it — including the hazard itself, so the loop can't quietly return.

```
786 passed, 46 deselected
```

## Still outstanding for 33.3

Log rotation on `/var/log/cfb-rankings/weekly.log` was never set up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)