### PR TITLE
chore: log rotation for cfb-rankings logs (closes Story 33.3)

### DIFF
--- a/deploy/logrotate-cfb-rankings
+++ b/deploy/logrotate-cfb-rankings
@@ -1,0 +1,32 @@
+# Log rotation for Stat-urday — EPIC-033 Story 33.3
+#
+# Install:  sudo cp deploy/logrotate-cfb-rankings /etc/logrotate.d/cfb-rankings
+# Verify:   sudo logrotate -d /etc/logrotate.d/cfb-rankings     # dry run
+# Force:    sudo logrotate -f /etc/logrotate.d/cfb-rankings     # rotate now
+#
+# Globs the whole directory because three different jobs write there:
+#   weekly.log         utilities/weekly_update.sh   (cron, user bdailey)
+#   weekly-update.log  scripts/weekly_update.py     (systemd timer, user www-data)
+#   update-games.log   scripts/update-production-data.sh (manual)
+
+/var/log/cfb-rankings/*.log {
+    monthly
+    rotate 12
+    # A weekly job writes ~4 entries per file, so 12 months of history.
+
+    compress
+    delaycompress
+    missingok
+    notifempty
+
+    # No mode/owner arguments: the replacement inherits them from the log it
+    # replaces. The writers run as different users (bdailey via cron, www-data
+    # via the systemd timer), so hardcoding one owner would break the other.
+    create
+
+    # A failing import can be noisy — cap the file even mid-month.
+    maxsize 10M
+
+    # If logrotate reports "parent directory has insecure permissions", add an
+    # su line matching the owner of /var/log/cfb-rankings, e.g. `su bdailey bdailey`.
+}

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -103,6 +103,12 @@ systemctl daemon-reload
 systemctl enable cfb-rankings
 systemctl start cfb-rankings
 
+# Install log rotation
+echo "🗒️  Installing log rotation..."
+mkdir -p /var/log/cfb-rankings
+cp deploy/logrotate-cfb-rankings /etc/logrotate.d/cfb-rankings
+logrotate -d /etc/logrotate.d/cfb-rankings >/dev/null && echo "  ✓ logrotate config valid"
+
 # Install Nginx configuration
 echo "🌐 Installing Nginx configuration..."
 # Update domain in config

--- a/docs/EPIC-033-2026-SEASON-DATA-PIPELINE.md
+++ b/docs/EPIC-033-2026-SEASON-DATA-PIPELINE.md
@@ -223,6 +223,19 @@ path. Fixed in PR #9.
 **Effort:** 3–4 hours
 **Completed:** 2026-05-04 — `utilities/weekly_update.sh` created and cron entry
 active (`0 9 * * 1`) on VPS. Logs to `/var/log/cfb-rankings/weekly.log`.
+Dry-run tested and two bugs fixed 2026-08-06; log rotation added the same day.
+
+> **⚠ Two weekly update paths exist.** `deploy/` also ships a systemd timer
+> (`cfb-weekly-update.timer`) that runs a *different* script,
+> `scripts/weekly_update.py`, as `www-data` on Sunday 22:00 UTC, logging to
+> `weekly-update.log`. The cron entry runs `utilities/weekly_update.sh` as
+> `bdailey` on Monday 09:00, logging to `weekly.log`. If both are enabled the
+> import runs twice a week from two code paths. Confirm which is actually live
+> before Week 1:
+> ```bash
+> crontab -l | grep weekly
+> systemctl list-timers cfb-weekly-update.timer
+> ```
 
 Set up a cron job on the VPS that runs every Monday morning to:
 1. Fetch the previous week's game results from CFBD
@@ -238,9 +251,21 @@ Set up a cron job on the VPS that runs every Monday morning to:
   - Saves a `ranking_history` snapshot for the week
   - Logs success/failure with timestamp
 - [x] Add cron entry on VPS: `0 9 * * 1 /var/www/cfb-rankings/utilities/weekly_update.sh >> /var/log/cfb-rankings/weekly.log 2>&1`
-- [ ] Test the script manually against Week 1 results before going live —
-  **still outstanding, do this before Aug 29**
-- [ ] Add log rotation for `/var/log/cfb-rankings/weekly.log`
+- [x] Test the script manually against Week 1 results before going live — done
+  2026-08-06 against a scratch DB copy. Found a data-loss bug: the ELO step
+  looped `save_weekly_rankings()` over every completed week, overwriting all
+  prior snapshots with current ratings (2025 week 14 went from Ohio State
+  1950.4 to Ole Miss 1696.0). Same bug in `src/importers/pipeline.py` and the
+  admin reprocess endpoint. Fixed and pinned by
+  `tests/unit/test_weekly_snapshot.py`.
+- [x] Add log rotation for `/var/log/cfb-rankings/weekly.log` —
+  `deploy/logrotate-cfb-rankings`, installed by `deploy/setup.sh`:
+  ```bash
+  sudo cp deploy/logrotate-cfb-rankings /etc/logrotate.d/cfb-rankings
+  sudo logrotate -d /etc/logrotate.d/cfb-rankings   # dry run, prints the plan
+  ```
+  Globs `/var/log/cfb-rankings/*.log` because three jobs write there — see the
+  note below on the two weekly update paths.
 
 **Acceptance Criteria:**
 - [x] Script runs end-to-end without manual intervention


### PR DESCRIPTION
Last outstanding task in EPIC-033 Story 33.3.

`logrotate` rather than anything in-process — it's the platform feature for this, already on the VPS, and needs no change to the scripts that write the logs.

## Config

`deploy/logrotate-cfb-rankings`, installed by `deploy/setup.sh` alongside the systemd and nginx configs.

- **Globs `/var/log/cfb-rankings/*.log`** instead of naming `weekly.log`. Three jobs write to that directory, not one (see below).
- **`create` with no mode or owner** so each replacement inherits them from the log it replaces. The writers run as *different users* — `bdailey` via cron, `www-data` via the systemd timer — so hardcoding either would break the other.
- **Monthly, 12 generations**, plus `maxsize 10M` so a failing import that turns noisy can't fill the disk before month end.

## Something worth knowing: two weekly update paths exist

| Path | Trigger | User | Log |
|---|---|---|---|
| `utilities/weekly_update.sh` | cron `0 9 * * 1` | `bdailey` | `weekly.log` |
| `scripts/weekly_update.py` | `deploy/cfb-weekly-update.timer`, Sun 22:00 UTC | `www-data` | `weekly-update.log` |
| `scripts/update-production-data.sh` | manual | — | `update-games.log` |

Two different scripts doing the same job on different schedules as different users. If both are enabled the import runs twice a week from two code paths — and note the snapshot fix in #12 only touched the shell one. Documented in the epic with the commands to check which is live:

```bash
crontab -l | grep weekly
systemctl list-timers cfb-weekly-update.timer
```

## Verification

`logrotate` isn't available on macOS, so the config is unvalidated locally. On the VPS:

```bash
sudo cp deploy/logrotate-cfb-rankings /etc/logrotate.d/cfb-rankings
sudo logrotate -d /etc/logrotate.d/cfb-rankings   # dry run, prints the plan
```

If it reports "parent directory has insecure permissions", add an `su` line matching the owner of `/var/log/cfb-rankings` — noted in a comment in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)