### PR TITLE
fix: ratings table loses the team column on mobile

### DIFF
--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -667,3 +667,44 @@
   .tkr-path-grid { flex-direction: column; gap: 8px; }
   .tkr-path-arrow { display: none; }
 }
+
+/* ── Ratings table: shed columns as the viewport narrows ──────────────────────
+   Every column except TEAM has a fixed track (~620px of them), so on a narrow
+   screen the fixed tracks hold their width and the 1fr TEAM column is the one
+   crushed to nothing — the team name disappears while SOS and the sparkline
+   survive. Dropping columns least-informative-first keeps RK / TEAM / ELO
+   readable all the way down.
+
+   Column order: 1 RK · 2 TEAM · 3 CONF · 4 W-L · 5 ELO · 6 Δ1W · 7 OFF ·
+                 8 DEF · 9 SOS · 10 10WK
+   Head and body rows share .tkr-grid, so one nth-child rule hides both. */
+
+@media (max-width: 1100px) {
+  /* 10WK sparkline — decorative next to the ELO number it summarizes */
+  .tkr-grid > div:nth-child(10) { display: none; }
+  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px; }
+}
+
+@media (max-width: 900px) {
+  /* OFF / DEF / SOS — available on the team detail view */
+  .tkr-grid > div:nth-child(7),
+  .tkr-grid > div:nth-child(8),
+  .tkr-grid > div:nth-child(9) { display: none; }
+  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px; }
+}
+
+@media (max-width: 640px) {
+  /* CONF and Δ1W — the conference stripe still carries the affiliation */
+  .tkr-grid > div:nth-child(3),
+  .tkr-grid > div:nth-child(6) { display: none; }
+  .tkr-grid { grid-template-columns: 40px 1fr 58px 72px; }
+  .tkr-grid > div { padding: 9px 8px; }
+}
+
+@media (max-width: 420px) {
+  /* Down to the irreducible three: rank, team, rating */
+  .tkr-grid > div:nth-child(4) { display: none; }
+  .tkr-grid { grid-template-columns: 34px 1fr 68px; }
+  .tkr-grid > div { padding: 9px 6px; }
+  .c-name { font-size: 12.5px; }
+}

--- a/tests/frontend/test_board_columns.js
+++ b/tests/frontend/test_board_columns.js
@@ -1,0 +1,130 @@
+// Self-check for the responsive ratings table.
+//   node tests/frontend/test_board_columns.js
+//
+// The table is a CSS grid whose columns are dropped as the viewport narrows.
+// The invariant: at every breakpoint the number of *visible* columns must equal
+// the number of tracks in grid-template-columns. Too many tracks leaves phantom
+// empty columns; too few makes cells wrap onto a second line. Media queries are
+// cumulative, so each narrower breakpoint inherits everything hidden above it.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const css = fs.readFileSync(
+  path.join(__dirname, '../../frontend/css/components/board.css'), 'utf8'
+);
+
+const TOTAL_COLUMNS = 10; // RK TEAM CONF W-L ELO Δ1W OFF DEF SOS 10WK
+
+/** Extract `@media (max-width: N px) { ... }` blocks, brace-matched. */
+function mediaBlocks(source) {
+  const blocks = [];
+  const re = /@media \(max-width:\s*(\d+)px\)\s*\{/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    let depth = 1;
+    let i = re.lastIndex;
+    while (i < source.length && depth > 0) {
+      if (source[i] === '{') depth++;
+      else if (source[i] === '}') depth--;
+      i++;
+    }
+    blocks.push({ width: Number(m[1]), body: source.slice(re.lastIndex, i - 1) });
+  }
+  return blocks;
+}
+
+/** Columns hidden by `.tkr-grid > div:nth-child(N)` rules inside a block. */
+function hiddenIn(body) {
+  const hidden = new Set();
+  const re = /\.tkr-grid\s*>\s*div:nth-child\((\d+)\)[^{]*\{[^}]*display:\s*none/g;
+  let m;
+  while ((m = re.exec(body)) !== null) hidden.add(Number(m[1]));
+
+  // Also handle the grouped form: several selectors sharing one display:none.
+  const grouped = /((?:\.tkr-grid\s*>\s*div:nth-child\(\d+\)\s*,\s*)+\.tkr-grid\s*>\s*div:nth-child\(\d+\))\s*\{[^}]*display:\s*none/g;
+  while ((m = grouped.exec(body)) !== null) {
+    const nums = m[1].match(/nth-child\((\d+)\)/g) || [];
+    nums.forEach((n) => hidden.add(Number(n.match(/\d+/)[0])));
+  }
+  return hidden;
+}
+
+/** Track count of the last grid-template-columns declared for .tkr-grid. */
+function trackCount(body) {
+  const re = /\.tkr-grid\s*\{[^}]*grid-template-columns:\s*([^;]+);/g;
+  let m, last = null;
+  while ((m = re.exec(body)) !== null) last = m[1];
+  if (last === null) return null;
+  return last.trim().split(/\s+/).length;
+}
+
+/** The stylesheet with every @media block removed, i.e. the base rules. */
+function withoutMediaBlocks(source) {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const start = source.indexOf('@media', i);
+    if (start === -1) { out += source.slice(i); break; }
+    out += source.slice(i, start);
+    let j = source.indexOf('{', start);
+    let depth = 1;
+    j++;
+    while (j < source.length && depth > 0) {
+      if (source[j] === '{') depth++;
+      else if (source[j] === '}') depth--;
+      j++;
+    }
+    i = j;
+  }
+  return out;
+}
+
+// Base (no media query): full 10 columns.
+const baseTracks = trackCount(withoutMediaBlocks(css));
+assert.strictEqual(
+  baseTracks, TOTAL_COLUMNS,
+  `base grid should declare ${TOTAL_COLUMNS} tracks, found ${baseTracks}`
+);
+
+// Walk breakpoints widest to narrowest, accumulating hidden columns.
+const blocks = mediaBlocks(css)
+  .filter((b) => hiddenIn(b.body).size > 0 || trackCount(b.body) !== null)
+  .sort((a, b) => b.width - a.width);
+
+assert.ok(blocks.length >= 3, 'expected several responsive breakpoints');
+
+const cumulativeHidden = new Set();
+let checked = 0;
+
+for (const block of blocks) {
+  hiddenIn(block.body).forEach((n) => cumulativeHidden.add(n));
+  const tracks = trackCount(block.body);
+  if (tracks === null) continue; // block hides nothing / redefines nothing
+
+  const visible = TOTAL_COLUMNS - cumulativeHidden.size;
+  assert.strictEqual(
+    tracks, visible,
+    `at max-width ${block.width}px: ${visible} columns visible but ${tracks} grid tracks declared ` +
+    `(hidden: ${[...cumulativeHidden].sort((a, b) => a - b).join(',')})`
+  );
+  checked++;
+
+  // RK (1), TEAM (2) and ELO (5) must survive every breakpoint — without them
+  // the table stops identifying which team a rating belongs to.
+  assert.ok(!cumulativeHidden.has(1), `RK hidden at ${block.width}px`);
+  assert.ok(!cumulativeHidden.has(2), `TEAM hidden at ${block.width}px`);
+  assert.ok(!cumulativeHidden.has(5), `ELO hidden at ${block.width}px`);
+}
+
+assert.ok(checked >= 3, `expected to verify at least 3 breakpoints, verified ${checked}`);
+
+// At the narrowest breakpoint we should be down to the essential three.
+const narrowest = blocks[blocks.length - 1];
+assert.strictEqual(
+  TOTAL_COLUMNS - cumulativeHidden.size, 3,
+  `narrowest breakpoint (${narrowest.width}px) should leave exactly RK/TEAM/ELO`
+);
+
+console.log(`board column self-check passed (${checked} breakpoints verified)`);


### PR DESCRIPTION
## Why the team name disappears

The ratings table is a CSS grid (`board.css:110`):

```css
grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px 84px;
```

Every column except TEAM has a **fixed** track — about 620px of them combined — and TEAM is the lone `1fr`. On a viewport narrower than those fixed tracks, they each hold their width and the `1fr` is the only thing that can give, so it collapses toward zero.

The result is backwards from what you want: SOS and the sparkline survive at 390px while the column identifying *which team the rating belongs to* vanishes.

## Fix

Shed columns least-informative-first as the viewport narrows, re-declaring the track list to match at each step:

| Breakpoint | Dropped | Rationale |
|---|---|---|
| ≤1100px | 10WK | Decorative beside the ELO number it summarizes |
| ≤900px | OFF, DEF, SOS | All present on the team detail view |
| ≤640px | CONF, Δ1W | The colour stripe still carries conference affiliation |
| ≤420px | W-L | Leaves rank, team, rating |

RK, TEAM and ELO survive every breakpoint. Head and body rows share `.tkr-grid`, so a single `nth-child` rule hides both together — and `.tkr-grid` is used by nothing else (`board.js:88,104`).

## Test

`tests/frontend/test_board_columns.js` checks the invariant that actually breaks layouts: **visible column count must equal declared grid track count at every breakpoint.** Too many tracks leaves phantom empty columns, too few makes cells wrap onto a second row. Media queries are cumulative, so it walks them widest to narrowest accumulating hidden columns, and asserts RK/TEAM/ELO are never among them.

```
$ node tests/frontend/test_board_columns.js
board column self-check passed (4 breakpoints verified)
```

Confirmed it fails on a deliberately mismatched track list before keeping it:

```
AssertionError: at max-width 1100px: 9 columns visible but 8 grid tracks declared (hidden: 10)
```

Writing the test also caught a bug in the test — splitting the stylesheet on the first `@media` truncated before `.tkr-grid`, since the countdown rule at line 36 comes first. It strips media blocks by brace-matching now.

## Not covered

No visual check on a real device — this is verified structurally, not rendered. Worth a look on your phone after deploy, particularly the 640px step where CONF and Δ1W go together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)