### PR TITLE
fix: CI flakiness — randomized hash() in test ids, plus a dead E2E job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,8 +111,11 @@ jobs:
       - name: Setup test database
         run: |
           python3 << 'EOF'
-          from database import Base, engine, SessionLocal
-          from models import Season, Team, ConferenceType
+          # Paths are src.* since the restructure — the old top-level
+          # `from database import ...` died with ModuleNotFoundError on every
+          # run, so the E2E job never actually reached the tests.
+          from src.models.database import Base, engine, SessionLocal
+          from src.models.models import Season, Team, ConferenceType
 
           # Create tables
           Base.metadata.create_all(bind=engine)

--- a/tests/unit/test_position_strength.py
+++ b/tests/unit/test_position_strength.py
@@ -171,9 +171,12 @@ class TestGetPositionGroupScores:
             ("DL 2", "DE", 91.0),
         ]
 
-        for name, position, rating in players_data:
+        for index, (name, position, rating) in enumerate(players_data):
             player = Player(
-                cfbd_athlete_id=hash(name) % 1000000,
+                # Index-derived, not hash(): string hashing is randomized per
+                # process, so hash-based ids collide at random and trip the
+                # unique constraint on cfbd_athlete_id.
+                cfbd_athlete_id=100000 + index,
                 name=name,
                 team_id=team.id,
                 position=position,
@@ -627,10 +630,14 @@ class TestCalculatePositionStrength:
         test_db.commit()
 
         # Add elite players across all positions (all 99.0 rating)
+        athlete_id = 200000
         for group_name, positions in POSITION_GROUPS.items():
             for pos in positions[:3]:  # Add 3 players per position
+                athlete_id += 1
                 player = Player(
-                    cfbd_athlete_id=hash(f"{group_name}{pos}") % 1000000,
+                    # Counter, not hash(): see the note above on randomized
+                    # string hashing colliding across processes.
+                    cfbd_athlete_id=athlete_id,
                     name=f"{pos} Elite",
                     team_id=team.id,
                     position=pos,

--- a/tests/unit/test_position_strength_integration.py
+++ b/tests/unit/test_position_strength_integration.py
@@ -333,10 +333,14 @@ class TestPositionStrengthIntegration:
 
         # Add perfect players at all positions
         positions = ["QB", "OL", "DL", "DB", "LB", "RB", "WR"]
-        for pos in positions:
+        for pos_index, pos in enumerate(positions):
             for i in range(5):
                 player = Player(
-                    cfbd_athlete_id=40000 + hash(f"{pos}{i}") % 10000,
+                    # Derived from the loop indices, not hash(): string hashing is
+                    # randomized per process, and 35 players drawn from a 10,000-wide
+                    # range collided about 5% of runs, tripping the unique constraint
+                    # on cfbd_athlete_id.
+                    cfbd_athlete_id=40000 + pos_index * 5 + i,
                     name=f"{pos} Player {i}",
                     team_id=team.id,
                     position=pos,

--- a/tests/unit/test_preseason_season_alignment.py
+++ b/tests/unit/test_preseason_season_alignment.py
@@ -1,3 +1,4 @@
+import itertools
 import pytest
 from unittest.mock import patch
 from sqlalchemy.orm import Session
@@ -23,6 +24,12 @@ def _make_team(db: Session, name: str, elo: float = 1500.0) -> Team:
     return team
 
 
+# Monotonic source of athlete ids. Not hash(name): string hashing is randomized
+# per process, so hash-derived ids collide at random and trip the unique
+# constraint on athlete_id.
+_athlete_ids = itertools.count(500000)
+
+
 def _make_roster_player(
     db: Session,
     team_id: int,
@@ -35,7 +42,7 @@ def _make_roster_player(
     player = RosterPlayer(
         season=season,
         team_id=team_id,
-        athlete_id=hash(name) % 1000000,
+        athlete_id=next(_athlete_ids),
         name=name,
         position=position,
         rating=rating,


### PR DESCRIPTION
Three things are behind the red CI. Two are ours; one isn't.

## 1. Randomized `hash()` in test athlete ids — the actual flake

`tests/unit/test_position_strength_integration.py:339` built ids as:

```python
cfbd_athlete_id=40000 + hash(f"{pos}{i}") % 10000,
```

String hashing is randomized per process (`PYTHONHASHSEED`), so those 35 ids are 35 random draws from a 10,000-wide range — a birthday problem. Measured empirically across 300 processes: **collides 5.0% of the time**, tripping the unique constraint on `players.cfbd_athlete_id`.

That explains the symptom that makes no sense otherwise: run 31109073128 failed on a **docs-only** PR where no code changed. It also explains why it always passes locally — you'd need to run it ~20 times to see it.

Three more sites used the same pattern against a 1,000,000-wide range — far less likely, same latent bug. All four now derive ids from loop indices or an `itertools.count`.

Verified with randomized hash seeds:

| | Failures |
|---|---|
| Before | 1 / 25 runs |
| After | 0 / 25 runs |

## 2. The E2E job has never run since the `src/` restructure

Its seed step still did `from database import ...` and `from models import ...`. Every run died with `ModuleNotFoundError: No module named 'database'` before reaching a single test. It's `continue-on-error: true`, so it failed quietly and never got blamed for anything.

Paths corrected to `src.models.*` and confirmed to resolve. `main.py` is tracked and re-exports the app correctly, so the server step should work — though note this job has not executed in long enough that the E2E tests themselves are unproven.

## 3. Runner provisioning — not fixable here

The two most recent failures (runs 31122234102, 31122119748) aren't test failures at all:

```
The job was not acquired by Runner of type hosted even after multiple attempts
Internal server error. Correlation ID: 71329605-e677-4c63-970c-57425f6fcc41
```

That's GitHub failing to hand out a runner; the job shows as `cancelled`, not `failure`. Nothing in the repo causes it and nothing in the repo fixes it — re-running is the only remedy. Worth knowing so it doesn't get mistaken for a code problem.

## Verification

```
368 passed  (-m unit)
132 passed  (-m integration)
786 passed  (-m "not e2e")
```

## Noted, not changed

Every run warns that `actions/checkout@v4`, `setup-python@v4`, `cache@v4` and `upload-artifact@v4` target Node 20, which is deprecated and currently being forced onto Node 24. Not failing yet. Happy to bump them separately rather than mixing it into a flake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)