### PR TITLE
feat: use away colours to separate same-hue teams in split bars

### DIFF
--- a/frontend/js/board.js
+++ b/frontend/js/board.js
@@ -35,19 +35,21 @@
   function abbrOf(e) { return abbrName(e.team_name); }
   function stripeOf(e) { return stripeName(e.team_name); }
 
-  // Two brand colors "clash" when their hexes are too close — recolor one for
-  // contrast in the split win-prob bar. ponytail: simple RGB distance.
   function rgb(hex) {
     var m = /^#?([0-9a-f]{6})$/i.exec(hex || '');
     if (!m) return null;
     var n = parseInt(m[1], 16);
     return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
   }
-  function clash(a, b) {
-    var ra = rgb(a), rb = rgb(b);
-    if (!ra || !rb) return false;
-    var d = Math.abs(ra[0] - rb[0]) + Math.abs(ra[1] - rb[1]) + Math.abs(ra[2] - rb[2]);
-    return d < 90;
+
+  // Colour for `awayName` in a split bar shared with `homeName`. Falls back to
+  // the away team's alternate colour when the two brands read as the same, so a
+  // red-vs-red matchup stays two team colours instead of one going grey.
+  function pairColor(awayName, homeName) {
+    var awayMeta = metaOf(awayName);
+    var homePrimary = metaOf(homeName).primary;
+    if (!window.TeamVisuals || !awayMeta.primary || !homePrimary) return stripeName(awayName);
+    return window.TeamVisuals.distinguish(awayMeta, homePrimary);
   }
 
   // d = rank_change (prevRank - rank). >0 up, <0 down, 0 flat.
@@ -727,8 +729,10 @@
 
   function predRow(p) {
     var aw = p.away_team, hm = p.home_team;
-    var awColor = stripeName(aw), hmColor = stripeName(hm);
-    if (clash(awColor, hmColor)) awColor = 'var(--fg3)';
+    var hmColor = stripeName(hm);
+    // The away side gives way when the two brands are hard to tell apart,
+    // preferring the away team's own alternate colour over a neutral.
+    var awColor = pairColor(aw, hm);
     var awP = Math.round(p.away_win_probability), hmP = Math.round(p.home_win_probability);
     var sep = p.is_neutral_site ? 'v' : '@';
     var margin = Math.abs(p.predicted_home_score - p.predicted_away_score);
@@ -782,8 +786,7 @@
 
   function matchCard(m) {
     var hi = m.high, lo = m.low, hiWin = m.winner_id === hi.team_id;
-    var hC = stripeName(hi.name), lC = stripeName(lo.name);
-    if (clash(hC, lC)) lC = 'var(--fg3)';
+    var hC = stripeName(hi.name), lC = pairColor(lo.name, hi.name);
     var label = m.neutral ? esc(m.label.toUpperCase()) : '△ ' + esc(abbrName(hi.name));
     return '<div class="bk-card"><div class="bk-label">' + label + '</div>' +
       '<div class="bk-box">' + bkTeamRow(hi, hiWin, hC) + bkTeamRow(lo, !hiWin, lC) +

--- a/frontend/js/team-visuals.js
+++ b/frontend/js/team-visuals.js
@@ -119,6 +119,82 @@
     return lightTheme ? '#4a4a4a' : '#b8bcc4';
   }
 
+  // ── Telling two teams apart in a split bar ──────────────────────────────────
+
+  var MIN_PAIR_CONTRAST = 1.6;  // lightness separation that reads at a glance
+  var MIN_HUE_DELTA = 40;       // degrees; below this two colours read as "same"
+  var GREY_SAT = 0.15;          // below this, hue carries no information
+
+  function hueDegrees(hsl) { return hsl[0] * 360; }
+
+  /**
+   * True when two colours are hard to tell apart side by side.
+   *
+   * Lightness alone can separate them (dark red vs pink), and hue alone can
+   * (red vs blue) — it takes *both* being close to be a problem. Near-greys are
+   * judged on lightness only, since their hue is noise.
+   */
+  function tooSimilar(a, b) {
+    var ra = parseHex(a), rb = parseHex(b);
+    if (!ra || !rb) return false;
+    if (contrast(ra, rb) >= MIN_PAIR_CONTRAST) return false;
+
+    var ha = rgbToHsl(ra), hb = rgbToHsl(rb);
+    if (ha[1] < GREY_SAT || hb[1] < GREY_SAT) return true;
+
+    var d = Math.abs(hueDegrees(ha) - hueDegrees(hb));
+    if (d > 180) d = 360 - d;
+    return d < MIN_HUE_DELTA;
+  }
+
+  /**
+   * Pick a colour for `away` that is distinguishable from `home` in a split bar.
+   *
+   * Ladder, stopping at the first rung that works:
+   *   1. the away team's own colour, if it already separates
+   *   2. the away team's alternate ("away") colour — keeps team identity
+   *   3. lightness-shift the away colour, preserving hue
+   *   4. a neutral, as a last resort
+   *
+   * Every candidate must also clear the panel contrast floor, so nothing
+   * returned here is invisible against the background.
+   */
+  function distinguish(awayMeta, homeColor, opts) {
+    opts = opts || {};
+    var lightTheme = opts.light !== undefined ? opts.light : isLightTheme();
+    var o = { light: lightTheme };
+    var home = readable(homeColor, o);
+
+    var away = readable((awayMeta && awayMeta.primary) || '', o);
+    if (!parseHex(away)) return away;
+    if (!tooSimilar(away, home)) return away;
+
+    // 2. The away team's alternate colour — still their brand.
+    if (awayMeta && awayMeta.secondary) {
+      var alt = readable(awayMeta.secondary, o);
+      if (parseHex(alt) && !tooSimilar(alt, home)) return alt;
+    }
+
+    // 3. Shift lightness, keeping hue so it still reads as the team's colour.
+    var surface = parseHex(lightTheme ? LIGHT_SURFACE : DARK_SURFACE);
+    var hsl = rgbToHsl(parseHex(away));
+    for (var dir = 0; dir < 2; dir++) {
+      var step = dir === 0 ? (lightTheme ? 0.03 : -0.03) : (lightTheme ? -0.03 : 0.03);
+      var l = hsl[2];
+      for (var i = 0; i < 33; i++) {
+        l = Math.max(0, Math.min(1, l + step));
+        var cand = toHex(hslToRgb([hsl[0], hsl[1], l]));
+        if (!tooSimilar(cand, home) && contrast(parseHex(cand), surface) >= MIN_CONTRAST) {
+          return cand;
+        }
+        if (l <= 0 || l >= 1) break;
+      }
+    }
+
+    // 4. Neutral. Distinguishable from any hue, still readable on the panel.
+    return lightTheme ? '#4a4a4a' : '#b8bcc4';
+  }
+
   /** CFBD logo URL for a team meta entry, or null when the team has no id. */
   function logoUrl(meta, size, opts) {
     opts = opts || {};
@@ -165,6 +241,8 @@
 
   var api = {
     readable: readable,
+    tooSimilar: tooSimilar,
+    distinguish: distinguish,
     contrast: function (a, b) {
       var ra = parseHex(a), rb = parseHex(b);
       return ra && rb ? contrast(ra, rb) : null;

--- a/tests/frontend/test_team_visuals.js
+++ b/tests/frontend/test_team_visuals.js
@@ -106,4 +106,53 @@ assert.ok(
 const missing = teams.filter(([, m]) => m.cfbd_id == null).map(([n]) => n);
 assert.strictEqual(missing.length, 0, `teams without a cfbd_id: ${missing.join(', ')}`);
 
-console.log(`team visuals self-check passed (${teams.length} teams, both themes)`);
+// ── Split-bar colour separation ──────────────────────────────────────────────
+
+// Same hue and similar lightness is the case that was slipping through: two
+// reds side by side read as one bar.
+assert.ok(TV.tooSimilar('#cc0000', '#b00000'), 'two similar reds are too similar');
+// Different hue at similar lightness is fine — red vs blue is legible.
+assert.ok(!TV.tooSimilar('#cc0000', '#0000cc'), 'red vs blue is distinguishable');
+// Same hue at very different lightness is fine — dark red vs pink.
+assert.ok(!TV.tooSimilar('#330000', '#ff9999'), 'dark vs light red is distinguishable');
+
+// Every ordered pair of real teams must come out separable, and none may be
+// left on the neutral if the team has a usable alternate colour.
+let unresolved = [];
+let viaNeutral = 0;
+for (const [awayName, awayMeta] of teams) {
+  for (const [homeName, homeMeta] of teams) {
+    if (awayName === homeName) continue;
+    for (const light of [false, true]) {
+      const home = TV.readable(homeMeta.primary, { light });
+      const away = TV.distinguish(awayMeta, homeMeta.primary, { light });
+      if (TV.tooSimilar(away, home)) unresolved.push(`${awayName} vs ${homeName} (light=${light})`);
+      // Whatever we pick must still be visible on the panel.
+      const surface = light ? TV.LIGHT_SURFACE : TV.DARK_SURFACE;
+      assert.ok(
+        TV.contrast(away, surface) >= TV.MIN_CONTRAST - 0.001,
+        `${awayName} vs ${homeName}: ${away} fails panel contrast`
+      );
+      if (away === '#b8bcc4' || away === '#4a4a4a') viaNeutral++;
+    }
+  }
+}
+assert.strictEqual(
+  unresolved.length, 0,
+  `pairs still indistinguishable: ${unresolved.slice(0, 5).join('; ')}`
+);
+assert.strictEqual(viaNeutral, 0, `${viaNeutral} pairs fell back to a neutral colour`);
+
+// The screenshot cases specifically: a red away team against a red home team
+// should end up on the away team's alternate, not grey.
+const usc = meta['USC'];
+const uscVsRed = TV.distinguish(usc, '#c8102e', { light: false }); // vs Houston red
+assert.ok(
+  !TV.tooSimilar(uscVsRed, TV.readable('#c8102e', { light: false })),
+  `USC vs a red opponent still clashes: ${uscVsRed}`
+);
+
+const pairs = teams.length * (teams.length - 1) * 2;
+console.log(
+  `team visuals self-check passed (${teams.length} teams, both themes, ${pairs} bar pairings)`
+);


### PR DESCRIPTION
Follow-up to #17. This commit landed on the branch after #17 was merged, so it was never included — this PR picks it up.

## What

When two teams in a prediction's split win-probability bar have near-identical brand hues, the bar reads as one solid block. This falls back to the away team's secondary colour to keep the split legible.

## Test plan

- [x] Full suite passes (789 tests, e2e excluded)
- [ ] Visual check on the predictions card for a same-hue matchup

🤖 Generated with [Claude Code](https://claude.com/claude-code)