### PR TITLE
fix: stop preseason schedule import from jumping current_week

### DIFF
--- a/docs/SEASON-RUNBOOK.md
+++ b/docs/SEASON-RUNBOOK.md
@@ -138,11 +138,22 @@ were imported correctly.
 ### 1g. Import the game schedule
 
 ```bash
-sudo -u www-data venv/bin/python3 import_real_data.py --season 2026
+sudo -u www-data venv/bin/python3 import_real_data.py --season 2026 --max-week 15
 ```
 
 This pulls all scheduled games (with 0-0 placeholder scores for future games) from the
 CFBD API and inserts them into the `games` table.
+
+**`--max-week` is required in the preseason.** Without it the pipeline auto-detects
+the max week from CFBD; before kickoff there is no week data, so it falls back to
+week 1 and you import only the opening weekend. Week 15 covers the full regular
+season plus Army–Navy. In-season (`utilities/weekly_update.sh`) auto-detection
+works fine and the flag is unnecessary.
+
+Re-running this is safe and idempotent — existing games are matched and updated
+in place. Re-run it if `game_date` is null on scheduled games (rows written before
+the camelCase `startDate` fix in `src/importers/common.py` have no date; a re-import
+backfills them).
 
 ### 1h. Restart the API service
 

--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -19,6 +19,7 @@
   height: 60px; display: flex; align-items: center; justify-content: space-between; gap: 16px;
 }
 .tkr-brand { display: flex; align-items: center; gap: 11px; }
+.tkr-home { display: flex; align-items: center; gap: 11px; text-decoration: none; }
 .tkr-badge {
   width: 27px; height: 27px; border-radius: 7px; background: var(--accent);
   display: flex; align-items: center; justify-content: center;

--- a/frontend/js/layout.js
+++ b/frontend/js/layout.js
@@ -40,8 +40,10 @@
     '<header class="tkr-header">' +
       '<div class="tkr-header-inner">' +
         '<div class="tkr-brand">' +
-          '<span class="tkr-badge">S</span>' +
-          '<span class="tkr-wordmark">STATURDAY<span class="dot">.TKR</span></span>' +
+          '<a class="tkr-home" href="index.html" aria-label="Staturday home">' +
+            '<span class="tkr-badge">S</span>' +
+            '<span class="tkr-wordmark">STATURDAY<span class="dot">.TKR</span></span>' +
+          '</a>' +
           '<span class="tkr-week" id="tkr-week"></span>' +
           '<span class="tkr-countdown" id="tkr-countdown"></span>' +
         '</div>' +

--- a/src/importers/__init__.py
+++ b/src/importers/__init__.py
@@ -12,6 +12,7 @@ from src.importers.common import (
     find_existing_game,
     get_or_create_fcs_team,
     parse_game_date,
+    resolve_final_week,
 )
 from src.importers.games import import_games
 from src.importers.pipeline import main
@@ -46,6 +47,7 @@ __all__ = [
     "main",
     "parse_game_date",
     "print_duplicate_report",
+    "resolve_final_week",
     "validate_api_connection",
     "validate_import_results",
 ]

--- a/src/importers/common.py
+++ b/src/importers/common.py
@@ -21,6 +21,18 @@ CONFERENCE_MAP = {
 }
 
 
+def resolve_final_week(latest_processed_week, current_week: int) -> int:
+    """Week the season should sit on after an import.
+
+    ``--max-week`` says how far the SCHEDULE was pulled, not how far the season
+    has played, so it is not a safe fallback. In preseason nothing is processed
+    yet and ``latest_processed_week`` is None; advancing to --max-week there
+    would jump current_week to 15 and stamp a 0-0 snapshot over the preseason
+    rankings. Stay put instead.
+    """
+    return latest_processed_week if latest_processed_week is not None else current_week
+
+
 def parse_game_date(game_data: dict) -> datetime:
     """
     Parse game date from CFBD API response.

--- a/src/importers/pipeline.py
+++ b/src/importers/pipeline.py
@@ -14,6 +14,7 @@ except (PermissionError, FileNotFoundError):
     pass
 
 from src.core.ranking_service import RankingService
+from src.importers.common import resolve_final_week
 from src.importers.games import import_games
 from src.importers.postseason import (
     import_bowl_games,
@@ -229,10 +230,9 @@ Examples:
         .first()
     )
 
-    if actual_max_week:
-        final_week = actual_max_week.week
-    else:
-        final_week = max_week
+    final_week = resolve_final_week(
+        actual_max_week.week if actual_max_week else None, season_obj.current_week
+    )
 
     # Update season current week to actual max
     season_obj.current_week = final_week

--- a/tests/integration/test_cfbd_import.py
+++ b/tests/integration/test_cfbd_import.py
@@ -313,3 +313,26 @@ class TestMockClientErrorHandling:
         alabama = team_objects["Alabama"]
         assert alabama.recruiting_rank == 999  # Default for unranked
         assert alabama.returning_production == 0.5  # Default
+
+
+@pytest.mark.integration
+class TestResolveFinalWeek:
+    """Which week an import leaves the season sitting on."""
+
+    def test_uses_latest_processed_week_in_season(self):
+        from src.importers import resolve_final_week
+
+        assert resolve_final_week(7, 6) == 7
+
+    def test_preseason_stays_put_instead_of_jumping_to_max_week(self):
+        # Nothing processed yet: --max-week 15 pulls the whole schedule, but the
+        # season is still on week 1. Advancing here would stamp a 0-0 snapshot
+        # over the preseason rankings.
+        from src.importers import resolve_final_week
+
+        assert resolve_final_week(None, 1) == 1
+
+    def test_week_zero_is_a_real_week_not_a_missing_one(self):
+        from src.importers import resolve_final_week
+
+        assert resolve_final_week(0, 5) == 0


### PR DESCRIPTION
Found while rehearsing the 2026 preseason runbook locally. Blocks season prep — kickoff is Aug 29.

## The bug

Running the documented §1g command in the preseason advanced the season to **week 15** and stamped a 0-0 ranking snapshot over the preseason rankings.

`main()` derives the post-import week from the latest *processed* game. Before kickoff nothing is processed, so the query returns `None` and the code fell back to `max_week` — but `--max-week` says how far the *schedule* was pulled, not how far the season has *played*.

Reproduced locally on the 2026 season:

| | before | after |
|---|---|---|
| `seasons.current_week` | 1 → **15** | **1** |
| bogus week-15 snapshot | 243 rows | none |
| rating drift wk0 vs wk1 | — | 0 teams |

## The other half

`--max-week` was missing from the runbook entirely. Without it, CFBD week auto-detection has no data before kickoff and falls back to week 1 — so §1g imported only the opening weekend. That's why prod currently has weeks 1–13 and no further.

Runbook §1g now specifies `--max-week 15` (full regular season + Army–Navy), explains why it's preseason-only, and documents that re-running backfills `game_date` on rows written before the camelCase `startDate` fix in `common.py`. **Prod has 678 of 777 2026 games with a null `game_date`** — a re-import after this lands fixes them.

## Also

One unrelated one-liner: the header logo now links home (`layout.js`, `board.css`). Shared header, so all pages get it.

## Test plan

- [x] `resolve_final_week()` extracted as a pure function, 3 tests covering in-season / preseason / week-0-is-real
- [x] Full suite: 789 passed (e2e excluded)
- [x] End-to-end: re-ran the real import against the 2026 schedule — 886 games, 0 null dates, `current_week` held at 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)