### PR TITLE
fix: show every week on the games page, not just the first page

### DIFF
--- a/frontend/games.html
+++ b/frontend/games.html
@@ -109,13 +109,9 @@
     <div class="tkr-filter-bar" style="display: flex; justify-content: space-between; align-items: center; padding: 10px 0; margin-bottom: 0.5rem;">
       <h2 style="font-family: var(--font-sans); font-size: 14.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg); margin: 0;">All Games</h2>
       <div class="filters">
+        <!-- Options are rebuilt from the loaded schedule by populateWeekFilter() -->
         <select class="filter-select" id="week-filter">
           <option value="">All Weeks</option>
-          <option value="1">Week 1</option>
-          <option value="2">Week 2</option>
-          <option value="3">Week 3</option>
-          <option value="4">Week 4</option>
-          <option value="5">Week 5</option>
         </select>
       </div>
     </div>
@@ -153,6 +149,7 @@
   </footer>
 
   <script src="js/api.js"></script>
+  <script src="js/paging.js"></script>
   <script src="js/date-utils.js"></script>
   <script src="js/season.js"></script>
   <script src="js/countdown.js"></script>
@@ -171,7 +168,7 @@
         const activeSeason = await api.getActiveSeason();
 
         const [gamesData, teamsData] = await Promise.all([
-          api.getGames({ season: activeSeason, limit: 200 }),
+          fetchAllGames(activeSeason),
           api.getTeams()
         ]);
 
@@ -180,12 +177,29 @@
         // Create teams lookup
         teamsData.forEach(t => teams[t.id] = t);
 
+        populateWeekFilter(allGames);
         displayGames(allGames);
         document.getElementById('loading').classList.add('hidden');
         document.getElementById('games-container').classList.remove('hidden');
       } catch (err) {
         console.error('Error loading games:', err);
       }
+    }
+
+    // A full season is ~900 games and the API caps limit at 500, so the old
+    // single limit=200 request truncated to whichever weeks sort first — the
+    // reason weeks past the cutoff rendered empty.
+    function fetchAllGames(season) {
+      return fetchAllPages((skip, limit) => api.getGames({ season, skip, limit }));
+    }
+
+    // Weeks were hardcoded 1-5. Build them from the schedule instead so bowl and
+    // championship weeks show up without another edit.
+    function populateWeekFilter(games) {
+      const select = document.getElementById('week-filter');
+      const weeks = [...new Set(games.map(g => g.week))].sort((a, b) => a - b);
+      select.innerHTML = '<option value="">All Weeks</option>' +
+        weeks.map(w => `<option value="${w}">Week ${w}</option>`).join('');
     }
 
     function filterGames() {

--- a/frontend/js/paging.js
+++ b/frontend/js/paging.js
@@ -1,0 +1,35 @@
+// Paging helper for list endpoints.
+//
+// The API caps `limit` at 500 while a full season runs ~900 games, so a single
+// request silently truncates to whichever rows sort first. Callers that need
+// the whole list must page.
+
+(function (global) {
+  'use strict';
+
+  /**
+   * Collect every page from a paged endpoint.
+   *
+   * @param {function(number, number): Promise<Array>} fetchPage - called with
+   *   (skip, limit); returns one page.
+   * @param {number} [pageSize=500] - rows per request.
+   * @returns {Promise<Array>} every row, in page order.
+   */
+  async function fetchAllPages(fetchPage, pageSize) {
+    var size = pageSize || 500;
+    var all = [];
+    for (var skip = 0; ; skip += size) {
+      var page = await fetchPage(skip, size);
+      all = all.concat(page);
+      // A short page means we reached the end. An exactly-full final page costs
+      // one extra empty request, which is cheaper than trusting a total count
+      // the endpoint does not return.
+      if (page.length < size) return all;
+    }
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { fetchAllPages: fetchAllPages };
+  }
+  global.fetchAllPages = fetchAllPages;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/tests/frontend/test_paging.js
+++ b/tests/frontend/test_paging.js
@@ -1,0 +1,52 @@
+// Self-check for the list paging helper.
+//   node tests/frontend/test_paging.js
+//
+// The bug this guards: games.html asked for limit=200 against a ~900-game
+// season, so every week outside the first page rendered empty.
+
+const assert = require('assert');
+const { fetchAllPages } = require('../../frontend/js/paging.js');
+
+// Build a fake endpoint over `total` rows that honours skip/limit and records
+// how it was called.
+function fakeEndpoint(total) {
+  const calls = [];
+  const rows = Array.from({ length: total }, (_, i) => i);
+  const fetchPage = (skip, limit) => {
+    calls.push([skip, limit]);
+    return Promise.resolve(rows.slice(skip, skip + limit));
+  };
+  return { fetchPage, calls };
+}
+
+(async () => {
+  // A real 2026 season: 894 games must all come back, not the first page.
+  const season = fakeEndpoint(894);
+  const all = await fetchAllPages(season.fetchPage);
+  assert.strictEqual(all.length, 894, 'every row must be collected');
+  assert.strictEqual(all[0], 0, 'first row preserved');
+  assert.strictEqual(all[893], 893, 'last row preserved');
+  assert.deepStrictEqual(season.calls, [[0, 500], [500, 500]], 'should page exactly twice');
+
+  // Fits in one page: must not make a second request.
+  const small = fakeEndpoint(12);
+  assert.strictEqual((await fetchAllPages(small.fetchPage)).length, 12);
+  assert.strictEqual(small.calls.length, 1, 'a short first page ends paging');
+
+  // Exactly one full page: needs the extra probe to learn it is done, and must
+  // terminate rather than loop on the empty response.
+  const exact = fakeEndpoint(500);
+  assert.strictEqual((await fetchAllPages(exact.fetchPage)).length, 500);
+  assert.strictEqual(exact.calls.length, 2, 'full final page costs one probe');
+
+  // Empty season must not hang.
+  const empty = fakeEndpoint(0);
+  assert.deepStrictEqual(await fetchAllPages(empty.fetchPage), []);
+
+  // Custom page size is honoured.
+  const custom = fakeEndpoint(25);
+  assert.strictEqual((await fetchAllPages(custom.fetchPage, 10)).length, 25);
+  assert.deepStrictEqual(custom.calls, [[0, 10], [10, 10], [20, 10]]);
+
+  console.log('✓ paging self-check passed');
+})();


### PR DESCRIPTION
Reported after the 2026 schedule import landed: the games page showed nothing for any week past week 1.

## Cause

Two independent truncations in the same load path.

**1. `limit: 200` on a 894-game season.** `games.html` fetched once, then filtered by week client-side. The response held only whichever weeks sort first, so selecting any other week filtered an already-truncated list down to nothing. Raising the number doesn't fix it — the API caps `limit` at 500, below a full season either way.

**2. The week dropdown was hardcoded to weeks 1–5**, hiding the back half of the season regardless.

Backend was fine throughout: `/api/games?season=2026&week=2` returns 86 games with dates.

## Fix

- `frontend/js/paging.js` — new `fetchAllPages(fetchPage, pageSize)`; pages until a short response arrives. Extracted rather than inlined so it's testable without a DOM.
- `games.html` — pages the endpoint, and builds the week options from the loaded schedule so championship/bowl weeks appear without another edit.

## Test plan

- [x] `tests/frontend/test_paging.js` — 894-row season pages exactly twice; single short page makes one call; exactly-500 case takes the extra probe and terminates; empty season doesn't hang; custom page size honoured
- [x] All four frontend self-checks pass (paging, countdown, team visuals, board columns)
- [x] Verified against prod data: 894 games, weeks 1–13 + Army–Navy; week 2 returns 86
- [ ] Visual check on cfb.bdailey.com after deploy

## Note

"All Weeks" now renders ~894 rows instead of 200. Fine at this size; if it ever drags, the fix is windowing the table, not re-truncating the fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)