### PR TITLE
fix: games page ordering, and stop silently dropping half the schedule

### DIFF
--- a/frontend/games.html
+++ b/frontend/games.html
@@ -212,7 +212,14 @@
       const tbody = document.getElementById('games-tbody');
       tbody.innerHTML = '';
 
-      games.sort((a, b) => b.week - a.week || b.id - a.id).forEach(game => {
+      // Chronological: week 1 first. Descending suited a results table mid-season,
+      // but this is mostly a forward schedule now. game_date breaks ties within a
+      // week; the few rows CFBD has not timed yet fall back to id.
+      games.sort((a, b) =>
+        a.week - b.week ||
+        (a.game_date || '').localeCompare(b.game_date || '') ||
+        a.id - b.id
+      ).forEach(game => {
         const row = document.createElement('tr');
 
         // Check if game has been played (scores exist)

--- a/frontend/games.html
+++ b/frontend/games.html
@@ -169,7 +169,10 @@
 
         const [gamesData, teamsData] = await Promise.all([
           fetchAllGames(activeSeason),
-          api.getTeams()
+          // getTeams() defaults to limit=100 against ~240 FBS teams. Any game
+          // whose team fell outside that first page hit the `!homeTeam` guard
+          // in displayGames() and was dropped from the table without a trace.
+          fetchAllPages((skip, limit) => api.getTeams(null, skip, limit))
         ]);
 
         allGames = gamesData;


### PR DESCRIPTION
Follow-up to #20. Two bugs, both surfaced once every week started loading.

## 1. Backwards ordering

`games.sort((a, b) => b.week - a.week || b.id - a.id)` — week descending. That read correctly when this was a results table mid-season, but 2026 is almost entirely unplayed, so it presented the schedule in reverse.

Now ascending, with `game_date` breaking ties within a week — `id` is insertion order, not kickoff order, and the import backfills dates so there's something real to sort on. The few games CFBD hasn't timed yet fall back to id.

## 2. Half the schedule was being dropped

Reported as "Ohio State v Texas isn't on week 2". The game was in the DB the whole time (id 1986, Sep 12). `getTeams()` defaults to `limit=100` while prod carries **243 teams**, so ~140 were missing from the lookup `displayGames()` builds. Every game with a team outside that first page hit this guard and disappeared with no error:

```js
if (!homeTeam || !awayTeam) return;
```

Texas is id 107 — just past the cutoff.

Measured against live prod data:

| | before | after |
|---|---|---|
| Renderable games | **397 / 894** | **894 / 894** |
| Week 2 rows | **24 / 86** | **86 / 86** |
| Ohio State @ Texas | dropped | renders |

Fixed with the same `fetchAllPages()` helper #20 introduced. `games.html` was the only unpaged `getTeams()` caller.

This predates today's import — it was invisible while prod held ~97 games, and the silent guard meant it looked like a complete table rather than a truncated one.

## Test plan

Verified against live prod data (894 games, 243 teams):

- [x] Week 1 first, Army–Navy (Dec 12) last; weeks non-decreasing across all 894 rows
- [x] Within week 2, all 86 games ascending by date
- [x] 894/894 games resolve both teams; Ohio State @ Texas among them
- [x] Paging self-check passes
- [ ] Visual check after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)