### PR TITLE
fix: simulator rank column, and drop internal jargon from the UI

### DIFF
--- a/frontend/css/components/cards.css
+++ b/frontend/css/components/cards.css
@@ -78,6 +78,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* Inside a narrow grid cell a flex item shrinks on the main axis only, which
+     turns the circle into an ellipse. Hold the width. */
+  flex-shrink: 0;
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;

--- a/frontend/css/components/simulator.css
+++ b/frontend/css/components/simulator.css
@@ -179,6 +179,9 @@
   color: var(--fg3);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  /* Fixed-width columns are sized for their cells, not their labels — let a
+     long header run rather than wrap to a second line. */
+  white-space: nowrap;
   padding: 12px 14px;
   border-bottom: 1px solid var(--line);
   display: flex;
@@ -210,6 +213,15 @@
 /* Cell Alignments & Formatting */
 .sim-grid-row .c-rk {
   justify-content: flex-start;
+  /* The default 14px side padding leaves 28px for a 30px badge. Trim it so the
+     badge keeps its circle at every breakpoint. */
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.sim-grid-row .c-rk .rank-badge {
+  width: 30px;
+  height: 30px;
+  font-size: 12.5px;
 }
 .sim-grid-row .c-chg {
   font-family: var(--font-mono);
@@ -397,6 +409,17 @@
 @media (max-width: 680px) {
   .sim-grid {
     grid-template-columns: 40px 45px 1fr 90px 75px;
+  }
+  /* Below this the rank column is narrower than any legible circle, and a
+     3-digit rank would not fit one anyway. Drop to a plain number. */
+  .sim-grid-row .c-rk .rank-badge {
+    width: auto;
+    height: auto;
+    background: none;
+    border: none;
+    border-radius: 0;
+    color: var(--fg);
+    font-size: 12px;
   }
   .sim-grid-header div:nth-child(4), /* CONF */
   .sim-grid-header div:nth-child(6), /* OFF RTNG */

--- a/frontend/js/board.js
+++ b/frontend/js/board.js
@@ -102,7 +102,7 @@
         (logoImgFor(e.team_name, 24) ||
           '<span class="c-stripe" style="background:' + stripeOf(e) + '"></span>') +
         '<span class="c-name">' + esc(e.team_name) + '</span></div>' +
-      '<div class="c-conf">' + esc(e.conference_name || e.conference || '') + '</div>' +
+      '<div class="c-conf">' + esc(TeamVisuals.confLabel(e.conference_name) || e.conference || '') + '</div>' +
       '<div class="c-wl ta-r">' + e.wins + '-' + e.losses + '</div>' +
       '<div class="c-elo ta-r">' + fmtElo(e.elo_rating) + '</div>' +
       '<div class="c-delta ta-r ' + trendClass(d) + '">' + deltaText(d) + '</div>' +
@@ -278,7 +278,7 @@
       badgeRow += '<span class="badge-rank">No. ' + e.rank + '</span>';
     }
     if (e.conference_name) {
-      badgeRow += '<span class="badge-conf">' + esc(e.conference_name) + '</span>';
+      badgeRow += '<span class="badge-conf">' + esc(TeamVisuals.confLabel(e.conference_name)) + '</span>';
     }
     badgeRow += '<span class="badge-record-wk">' + e.wins + '–' + e.losses + ' · WK' + CURRENT_WEEK + '</span>';
 
@@ -802,7 +802,7 @@
     return '<div class="bk-champ"><div class="bk-champ-lbl">◆ TITLE FAVORITE</div>' +
       '<div class="bk-champ-name"><span class="bk-stripe" style="background:' + c + '"></span>' + esc(abbrName(ch.name)) + '</div>' +
       '<div class="bk-champ-full">' + esc(ch.name) + '</div>' +
-      '<div class="bk-champ-sub">No. ' + ch.seed + ' SEED · ' + esc(ch.conference_name || '') + '</div>' +
+      '<div class="bk-champ-sub">No. ' + ch.seed + ' SEED · ' + esc(TeamVisuals.confLabel(ch.conference_name)) + '</div>' +
       '<div class="bk-champ-win"><span>TITLE-GAME WIN</span><span class="v">' + Math.round(ch.title_game_win_prob) + '%</span></div></div>';
   }
 

--- a/frontend/js/matchup.js
+++ b/frontend/js/matchup.js
@@ -370,8 +370,8 @@ function renderStatsGrid(data) {
   document.getElementById('stat-rec-a').textContent = `${a.wins}–${a.losses}`;
   document.getElementById('stat-rec-b').textContent = `${b.wins}–${b.losses}`;
 
-  document.getElementById('stat-conf-a').textContent = statVal(a.conference_name || a.conference);
-  document.getElementById('stat-conf-b').textContent = statVal(b.conference_name || b.conference);
+  document.getElementById('stat-conf-a').textContent = statVal(TeamVisuals.confLabel(a.conference_name) || a.conference);
+  document.getElementById('stat-conf-b').textContent = statVal(TeamVisuals.confLabel(b.conference_name) || b.conference);
   document.getElementById('stat-conf-a').style.color = 'var(--fg2)';
   document.getElementById('stat-conf-b').style.color = 'var(--fg2)';
   document.getElementById('stat-conf-a').style.fontWeight = '500';

--- a/frontend/js/simulator.js
+++ b/frontend/js/simulator.js
@@ -297,11 +297,10 @@ function render() {
     var rowId = 'row-' + team.team_id;
     var breakdownId = 'breakdown-' + team.team_id;
 
-    // Bold simulated ranks for top 4 using inline accent style
-    var rankStyle = rank <= 4 ? 'font-weight: 700; color: var(--accent);' : '';
-
     rows += '<div class="sim-grid-row" id="' + rowId + '" onclick="toggleBreakdown(' + team.team_id + ')">' +
-      '<div class="c-rk"><span class="' + rankClass(rank) + '" style="' + rankStyle + '">' + rank + '</span></div>' +
+      // No inline colour here: .rank-badge.top-5 already paints the badge with
+      // var(--accent), so tinting the text to match rendered ranks 1-4 invisible.
+      '<div class="c-rk"><span class="' + rankClass(rank) + '">' + rank + '</span></div>' +
       '<div class="c-chg ' + chgClass + '">' + chgStr + '</div>' +
       '<div class="c-team">' +
         '<span class="c-stripe" style="background:' + stripeName(team.team_name) + '"></span>' +

--- a/frontend/js/team-visuals.js
+++ b/frontend/js/team-visuals.js
@@ -239,7 +239,22 @@
     }
   }
 
+  // Display names for conferences whose CFBD label is too long for a table
+  // cell. Presentation only — the stored value stays as CFBD sends it, because
+  // ranking_service matches independents on the exact string.
+  var CONF_LABELS = {
+    'FBS Independents': 'Ind',
+    'Independents': 'Ind',
+    'Independent': 'Ind',
+  };
+
+  function confLabel(name) {
+    if (!name) return '';
+    return CONF_LABELS[name] || name;
+  }
+
   var api = {
+    confLabel: confLabel,
     readable: readable,
     tooSimilar: tooSimilar,
     distinguish: distinguish,

--- a/frontend/simulator.html
+++ b/frontend/simulator.html
@@ -92,7 +92,7 @@
 
         <!-- Group 2: Previous Season Regression -->
         <div class="slider-group">
-          <h3>Previous Season Regression (EPIC-030)</h3>
+          <h3>Previous Season Regression</h3>
           <p class="slider-group-desc">Controls how much prior season performance influences the preseason rating</p>
 
           <div class="slider-row">

--- a/tests/frontend/test_team_visuals.js
+++ b/tests/frontend/test_team_visuals.js
@@ -156,3 +156,22 @@ const pairs = teams.length * (teams.length - 1) * 2;
 console.log(
   `team visuals self-check passed (${teams.length} teams, both themes, ${pairs} bar pairings)`
 );
+
+// ── Conference display labels ──
+// "FBS Independents" overflows a table cell. Shortened for display only; the
+// stored value must stay intact because ranking_service matches on the exact
+// string when deciding who counts as an independent.
+assert.strictEqual(TV.confLabel('FBS Independents'), 'Ind');
+assert.strictEqual(TV.confLabel('Independents'), 'Ind');
+assert.strictEqual(TV.confLabel('Independent'), 'Ind');
+
+// Everything else passes through untouched.
+assert.strictEqual(TV.confLabel('Big Ten'), 'Big Ten');
+assert.strictEqual(TV.confLabel('Mountain West'), 'Mountain West');
+
+// Missing/empty conference must render as empty, never "undefined".
+assert.strictEqual(TV.confLabel(null), '');
+assert.strictEqual(TV.confLabel(undefined), '');
+assert.strictEqual(TV.confLabel(''), '');
+
+console.log('conference label self-check passed');


### PR DESCRIPTION
## 1. Ranks 1–4 rendered as blank orange ovals

Two bugs stacked on the same element.

**Invisible digits.** `simulator.js` set an inline `color: var(--accent)` for the top four, but `.rank-badge.top-5` already paints the badge *background* with the same token — accent text on an accent fill. Rank 5 gets the class without the inline override, which is exactly why 5 was readable and 1–4 weren't. The class alone carries the emphasis, so the override is gone.

**Ellipse, not circle.** The badge is 40px wide in a cell with 28px of usable width (56px column − 28px padding). A flex item shrinks on the main axis only, so it squashed horizontally while keeping full height. Fixed with `flex-shrink: 0`, trimmed cell padding, and a badge sized to the column.

Below 680px the rank column is narrower than any legible circle — and a 3-digit rank wouldn't fit one regardless — so it degrades to a plain number there.

## 2. `SIM RK` wrapped to two lines

Same 28px cell. Fixed-width columns are sized for their cells, not their labels, so headers no longer wrap.

## 3. EPIC references

`EPIC-030` was leaking into a user-facing heading on the simulator. That was the **only** rendered instance — I checked HTML text nodes, attributes, and JS string literals. The rest are code and CSS comments plus one JS variable name, none of which reach the DOM. Left those alone as useful history; say the word if you want them scrubbed too.

## 4. "FBS Independents" → "Ind"

Presentation-layer map in `team-visuals.js`, applied at the five render sites in `board.js` and `matchup.js`.

Deliberately **not** changed in the data: `src/core/ranking_service.py:1219` matches independents on the exact string `"FBS Independents"`, and `board.js` filter logic compares `conference_name` as data. Only display calls go through `confLabel()`.

## Test plan

- [x] `confLabel()` tests: all three independent spellings → `Ind`; other conferences pass through; null/undefined/empty → `''` rather than `"undefined"`
- [x] All four frontend self-checks pass (team visuals incl. 36180 bar pairings, paging, countdown, board columns)
- [x] Verified `team-visuals.js` loads before `board.js` / `matchup.js` on both pages
- [ ] Visual check on the simulator after deploy — ranks 1–4 legible, badges circular, header on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)