### PR TITLE
feat: record CFBD's reported call limit instead of estimating it

### DIFF
--- a/migrations/migrate_add_calllimit_remaining.py
+++ b/migrations/migrate_add_calllimit_remaining.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Database Migration: Add calllimit_remaining to api_usage
+
+CFBD reports the account's remaining monthly calls on every response via the
+`x-calllimit-remaining` header. Recording it makes quota reporting authoritative
+instead of derived: the local api_usage row count only sees calls made from this
+host (prod and dev each undercount), and CFBD_MONTHLY_LIMIT is a hand-configured
+value that silently goes stale when the plan changes.
+
+Purpose:
+    - Add nullable calllimit_remaining column to api_usage
+
+Idempotent:
+    - Checks for the column first; re-running is a no-op
+
+Rollback:
+    SQLite cannot drop columns before 3.35. The column is nullable and unused by
+    older code, so leaving it in place is harmless.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+
+def migrate(db_path: Path = None) -> int:
+    """Add the calllimit_remaining column if it is not already present."""
+    db_path = db_path or project_root / "cfb_rankings.db"
+
+    if not db_path.exists():
+        print(f"❌ Database not found: {db_path}")
+        return 1
+
+    print(f"Migrating {db_path}")
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+
+        cursor.execute("PRAGMA table_info(api_usage)")
+        columns = [row[1] for row in cursor.fetchall()]
+
+        if not columns:
+            print("❌ Table 'api_usage' does not exist — run the app once to create it")
+            conn.close()
+            return 1
+
+        if "calllimit_remaining" in columns:
+            print("⚠️  Column 'calllimit_remaining' already exists — nothing to do")
+            conn.close()
+            return 0
+
+        cursor.execute("ALTER TABLE api_usage ADD COLUMN calllimit_remaining INTEGER")
+        conn.commit()
+        conn.close()
+
+        print("✓ Added calllimit_remaining column to api_usage")
+        print()
+        print("Existing rows stay NULL — the value is only known for calls made")
+        print("after this migration. The next CFBD call populates it.")
+        print()
+        print("Next steps:")
+        print("  1. Restart the API service")
+        print("  2. Check /api/admin/api-usage for reported_remaining_calls")
+        return 0
+
+    except sqlite3.OperationalError as e:
+        if "duplicate column name" in str(e).lower():
+            print("⚠️  Column 'calllimit_remaining' already exists — migration already applied")
+            return 0
+        print(f"❌ Migration failed: {e}")
+        return 1
+    except Exception as e:
+        print(f"❌ Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(migrate())

--- a/src/integrations/cfbd_client.py
+++ b/src/integrations/cfbd_client.py
@@ -62,6 +62,43 @@ _warning_thresholds_logged = {
 }
 
 
+# Remaining monthly calls as last reported by CFBD. The tracking decorator wraps
+# _get and only sees its parsed return value, so _get stashes the header here for
+# it to pick up. Single-threaded import scripts and one request per call make a
+# module-level slot sufficient.
+# ponytail: not thread-safe — if calls ever go concurrent, a row could record a
+# sibling request's figure. Move it onto the response path proper if that happens.
+_last_calllimit_remaining = None
+
+CALLLIMIT_HEADER = "x-calllimit-remaining"
+
+
+def record_calllimit_remaining(response) -> "int | None":
+    """Capture CFBD's remaining-calls header off a response.
+
+    Returns the parsed value, or None when the header is absent or unparseable —
+    a malformed header must never break the API call that carried it.
+    """
+    global _last_calllimit_remaining
+    try:
+        raw = response.headers.get(CALLLIMIT_HEADER)
+    except AttributeError:
+        return None
+    if raw is None:
+        return None
+    try:
+        _last_calllimit_remaining = int(raw)
+    except (TypeError, ValueError):
+        logger.debug(f"Unparseable {CALLLIMIT_HEADER}: {raw!r}")
+        return None
+    return _last_calllimit_remaining
+
+
+def get_last_calllimit_remaining() -> "int | None":
+    """Most recent remaining-calls figure CFBD reported, or None if unseen."""
+    return _last_calllimit_remaining
+
+
 def track_api_usage(func):
     """
     Decorator to track CFBD API usage in database.
@@ -103,6 +140,7 @@ def track_api_usage(func):
                     status_code=status_code,
                     response_time_ms=response_time_ms,
                     month=month,
+                    calllimit_remaining=get_last_calllimit_remaining(),
                 )
                 db.add(usage_record)
                 db.commit()
@@ -184,6 +222,36 @@ def get_monthly_usage(month: str = None, db: "Session" = None) -> dict:
             .all()
         )
 
+        # CFBD's own figure, from the most recent response that carried the
+        # header. Authoritative where the local count is not: api_usage only sees
+        # calls made from this host, so prod and dev each undercount, and
+        # CFBD_MONTHLY_LIMIT is a hand-configured guess that goes stale on a plan
+        # change. Prefer it when present and fall back to the estimate.
+        reported_remaining = (
+            db.query(APIUsage.calllimit_remaining)
+            .filter(APIUsage.month == month, APIUsage.calllimit_remaining.isnot(None))
+            .order_by(APIUsage.id.desc())
+            .limit(1)
+            .scalar()
+        )
+
+        # Calls consumed account-wide, which is what the plan is actually
+        # measured against — derived only when CFBD has told us something.
+        reported_limit = None
+        if reported_remaining is not None:
+            effective_remaining = reported_remaining
+            # The configured limit is the only stated total we have; if it is
+            # below what CFBD says is left, the plan was upgraded and the config
+            # is stale. Surface the discrepancy rather than reporting nonsense.
+            reported_limit = max(monthly_limit, reported_remaining)
+            percentage_used = (
+                ((reported_limit - reported_remaining) / reported_limit) * 100
+                if reported_limit > 0
+                else 0
+            )
+        else:
+            effective_remaining = remaining_calls
+
         # Determine warning level
         warning_level = None
         if percentage_used >= 95:
@@ -198,7 +266,15 @@ def get_monthly_usage(month: str = None, db: "Session" = None) -> dict:
             "total_calls": total_calls,
             "monthly_limit": monthly_limit,
             "percentage_used": round(percentage_used, 2),
-            "remaining_calls": remaining_calls,
+            "remaining_calls": effective_remaining,
+            # Nulls mean CFBD has not reported yet this month (no calls made, or
+            # rows predate the column) — the numbers above are then local estimates.
+            "reported_remaining_calls": reported_remaining,
+            "reported_limit": reported_limit,
+            "locally_counted_remaining": remaining_calls,
+            "limit_config_stale": (
+                reported_remaining is not None and reported_remaining > monthly_limit
+            ),
             "average_calls_per_day": round(avg_per_day, 2),
             "warning_level": warning_level,
             "top_endpoints": [
@@ -326,6 +402,9 @@ class CFBDClient:
         for attempt in range(4):
             try:
                 response = requests.get(url, headers=self.headers, params=params)
+                # Record before any early exit — a 429 still carries the header,
+                # and that is exactly when the real number matters most.
+                record_calllimit_remaining(response)
                 if response.status_code == 429:
                     wait = 30 * (attempt + 1)
                     print(f"  Rate limited (429). Waiting {wait}s before retry {attempt + 1}/3...")

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -585,6 +585,12 @@ class APIUsage(Base):
     status_code = Column(Integer, nullable=False)
     response_time_ms = Column(Float, default=0.0)
     month = Column(String(7), index=True, nullable=False)  # YYYY-MM format
+    # CFBD returns the account's remaining monthly calls on every response
+    # (x-calllimit-remaining). Authoritative, unlike counting local rows: it
+    # accounts for calls made from other hosts and needs no configured limit.
+    # Null for rows written before this column existed, or if the header is
+    # missing from a response.
+    calllimit_remaining = Column(Integer, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     def __repr__(self):

--- a/tests/test_cfbd_client.py
+++ b/tests/test_cfbd_client.py
@@ -521,3 +521,130 @@ class TestGetCurrentSeasonWithDateLogic:
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
 
         assert client.get_current_season() == 2025  # Playoffs ongoing
+
+
+class TestCallLimitHeader:
+    """CFBD reports remaining monthly calls on every response.
+
+    This is the only authoritative quota figure: counting api_usage rows misses
+    calls made from other hosts, and CFBD_MONTHLY_LIMIT is hand-configured and
+    goes stale on a plan change.
+    """
+
+    def _response(self, headers):
+        response = Mock()
+        response.headers = headers
+        return response
+
+    def test_parses_header(self):
+        from src.integrations.cfbd_client import record_calllimit_remaining
+
+        assert record_calllimit_remaining(self._response({"x-calllimit-remaining": "28989"})) == 28989
+
+    def test_last_value_is_readable_by_the_tracking_decorator(self):
+        from src.integrations.cfbd_client import (
+            get_last_calllimit_remaining,
+            record_calllimit_remaining,
+        )
+
+        record_calllimit_remaining(self._response({"x-calllimit-remaining": "1234"}))
+        assert get_last_calllimit_remaining() == 1234
+
+    def test_missing_header_returns_none(self):
+        from src.integrations.cfbd_client import record_calllimit_remaining
+
+        assert record_calllimit_remaining(self._response({})) is None
+
+    def test_garbage_header_does_not_raise(self):
+        """A malformed header must never break the API call that carried it."""
+        from src.integrations.cfbd_client import record_calllimit_remaining
+
+        assert record_calllimit_remaining(self._response({"x-calllimit-remaining": "lots"})) is None
+        assert record_calllimit_remaining(self._response({"x-calllimit-remaining": None})) is None
+
+    def test_response_without_headers_does_not_raise(self):
+        from src.integrations.cfbd_client import record_calllimit_remaining
+
+        assert record_calllimit_remaining(object()) is None
+
+
+class TestMonthlyUsageReporting:
+    """get_monthly_usage prefers CFBD's figure over the local estimate."""
+
+    def _seed(self, db, month, rows):
+        from src.models.models import APIUsage
+
+        for remaining in rows:
+            db.add(
+                APIUsage(
+                    endpoint="/games",
+                    status_code=200,
+                    response_time_ms=1.0,
+                    month=month,
+                    calllimit_remaining=remaining,
+                )
+            )
+        db.commit()
+
+    def test_uses_most_recent_reported_figure(self, test_db, monkeypatch):
+        from src.integrations.cfbd_client import get_monthly_usage
+
+        monkeypatch.setenv("CFBD_MONTHLY_LIMIT", "30000")
+        # Three calls; the newest row carries the current figure.
+        self._seed(test_db, "2026-08", [28991, 28990, 28989])
+
+        usage = get_monthly_usage("2026-08", db=test_db)
+
+        assert usage["reported_remaining_calls"] == 28989
+        assert usage["remaining_calls"] == 28989
+        # Local count sees only its own 3 rows and would claim 29997.
+        assert usage["locally_counted_remaining"] == 29997
+
+    def test_falls_back_to_local_estimate_when_unreported(self, test_db, monkeypatch):
+        from src.integrations.cfbd_client import get_monthly_usage
+
+        monkeypatch.setenv("CFBD_MONTHLY_LIMIT", "30000")
+        self._seed(test_db, "2026-08", [None, None])
+
+        usage = get_monthly_usage("2026-08", db=test_db)
+
+        assert usage["reported_remaining_calls"] is None
+        assert usage["remaining_calls"] == 29998
+
+    def test_flags_a_stale_configured_limit(self, test_db, monkeypatch):
+        """More calls left than the configured ceiling means the plan was upgraded."""
+        from src.integrations.cfbd_client import get_monthly_usage
+
+        monkeypatch.setenv("CFBD_MONTHLY_LIMIT", "30000")
+        self._seed(test_db, "2026-08", [45000])
+
+        usage = get_monthly_usage("2026-08", db=test_db)
+
+        assert usage["limit_config_stale"] is True
+        assert usage["reported_limit"] == 45000
+        # Must not report a negative or >100% usage off the stale ceiling.
+        assert 0 <= usage["percentage_used"] <= 100
+
+    def test_percentage_tracks_the_reported_figure(self, test_db, monkeypatch):
+        from src.integrations.cfbd_client import get_monthly_usage
+
+        monkeypatch.setenv("CFBD_MONTHLY_LIMIT", "1000")
+        self._seed(test_db, "2026-08", [250])  # 750 of 1000 consumed
+
+        usage = get_monthly_usage("2026-08", db=test_db)
+
+        assert usage["percentage_used"] == 75.0
+        assert usage["warning_level"] is None  # below the 80% threshold
+
+    def test_warning_level_fires_off_the_reported_figure(self, test_db, monkeypatch):
+        """The threshold must follow CFBD's number, not the local row count."""
+        from src.integrations.cfbd_client import get_monthly_usage
+
+        monkeypatch.setenv("CFBD_MONTHLY_LIMIT", "1000")
+        # One local row, so the local estimate would say 0.1% used and stay silent.
+        self._seed(test_db, "2026-08", [80])  # 920 of 1000 actually consumed
+
+        usage = get_monthly_usage("2026-08", db=test_db)
+
+        assert usage["percentage_used"] == 92.0
+        assert usage["warning_level"] == "90%"


### PR DESCRIPTION
Quota reporting was derived from two unreliable things: a count of local `api_usage` rows, and a hand-configured `CFBD_MONTHLY_LIMIT`. The row count only sees calls made from *this* host, so prod and dev each undercount independently; the configured limit goes stale silently whenever the plan changes.

CFBD returns the authoritative number on every response:

```
x-calllimit-remaining: 28989
```

## Measured gap

Verified against the live API on this branch:

| | |
|---|---|
| CFBD reports remaining | **28,988** |
| Local estimate claimed | 29,566 |
| Gap | **578** — prod's calls, invisible to the local DB |

## Changes

- `cfbd_client._get()` captures the header on every response, including 429s — that's exactly when the real number matters most.
- New nullable `api_usage.calllimit_remaining` column + idempotent migration.
- `get_monthly_usage()` prefers the reported figure, falls back to the old estimate when the header hasn't been seen this month, derives the limit rather than trusting config, and sets `limit_config_stale` when CFBD says more calls remain than the configured ceiling allows — the signal that the plan was upgraded and `.env` wasn't.
- Warning thresholds (80/90/95%) now fire off the real number. Previously a host with few local rows would stay silent at 92% actual usage; there's a test for exactly that.

The tracking decorator wraps `_get` and only sees its parsed return value, so `_get` stashes the header in a module-level slot for it. Marked `ponytail:` as not thread-safe — single-threaded import scripts make that sufficient today, and the comment names the upgrade path.

## Test plan

- [x] 10 new tests: header parsing, missing header, garbage header, response with no `headers` attribute, most-recent-row selection, fallback when unreported, stale-limit flagging, percentage tracking the reported figure, warning threshold firing off it
- [x] 801 passed (full suite, e2e excluded)
- [x] Migration applied locally, verified idempotent on re-run
- [x] End-to-end against the real CFBD API — one call, value recorded and surfaced

## Deploy

```bash
sudo -u www-data venv/bin/python3 migrations/migrate_add_calllimit_remaining.py
sudo systemctl restart cfb-rankings
```

Existing rows stay NULL; the next CFBD call populates it. Until then the endpoint reports the old estimate, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)