### PR TITLE
fix: treat the preseason as a graceful skip, not a weekly update failure

### DIFF
--- a/scripts/weekly_update.py
+++ b/scripts/weekly_update.py
@@ -420,13 +420,21 @@ def main():
     logger.info("Check 2: Detecting current week from CFBD API...")
     try:
         current_week = get_current_week_wrapper()
-        if not current_week:
-            logger.warning(
-                "Could not detect current week - aborting weekly update. "
-                "This may indicate the season hasn't started yet."
+        if current_week is None:
+            # Between Aug 1 and kickoff, is_active_season() is already True (it
+            # is calendar-based) while CFBD has no completed games to derive a
+            # week from. That is the normal state for roughly four weeks, not a
+            # failure — exiting non-zero here marked the unit failed on every
+            # run and buried any genuine problem in the noise.
+            #
+            # A real API failure is not this branch: get_current_week_wrapper()
+            # re-raises those, and the handler below catches them and exits 1.
+            logger.info(
+                "No completed games yet - season has not kicked off. "
+                "Skipping weekly update (this is normal in the preseason)."
             )
             logger.info("=" * 80)
-            sys.exit(1)
+            sys.exit(0)  # Graceful exit - not an error
             return  # Prevent execution from continuing in tests where sys.exit is mocked
         logger.info(f"✓ Current week: {current_week}")
     except Exception as e:

--- a/tests/test_weekly_update.py
+++ b/tests/test_weekly_update.py
@@ -250,10 +250,36 @@ class TestMainFunction:
     @patch("weekly_update.is_active_season")
     @patch("weekly_update.get_current_week_wrapper")
     @patch("weekly_update.sys.exit")
-    def test_no_current_week_exits_with_error(self, mock_exit, mock_get_week, mock_is_active):
-        """No current week should exit with error code 1"""
+    def test_preseason_no_current_week_exits_gracefully(
+        self, mock_exit, mock_get_week, mock_is_active
+    ):
+        """Calendar-active but not yet kicked off is normal, not a failure.
+
+        is_active_season() turns true on Aug 1 while the first game is ~4 weeks
+        out, so CFBD has no completed games to derive a week from. Exiting
+        non-zero there marked the systemd unit failed on every run for a month
+        and buried any real problem in the noise.
+        """
         mock_is_active.return_value = True
         mock_get_week.return_value = None
+
+        weekly_update.main()
+
+        mock_exit.assert_called_once_with(0)
+
+    @patch("weekly_update.is_active_season")
+    @patch("weekly_update.get_current_week_wrapper")
+    @patch("weekly_update.sys.exit")
+    def test_week_detection_failure_still_exits_with_error(
+        self, mock_exit, mock_get_week, mock_is_active
+    ):
+        """A genuine CFBD failure must stay an error.
+
+        get_current_week_wrapper() re-raises API failures rather than returning
+        None, so the graceful-skip path above must not swallow them.
+        """
+        mock_is_active.return_value = True
+        mock_get_week.side_effect = Exception("CFBD unreachable")
 
         weekly_update.main()
 


### PR DESCRIPTION
The systemd unit has failed on **every run since Aug 1** — Aug 2, a manual run today, and it would have failed again Sunday Aug 9.

```
cfb-weekly-update.service: Main process exited, code=exited, status=1/FAILURE
```

## Cause

`is_active_season()` is calendar-based and turns true on **Aug 1**. Kickoff is **Aug 29**. For those four weeks CFBD has no completed games, so `get_current_week_wrapper()` returns `None` — and `main()` treated that as fatal:

```python
current_week = get_current_week_wrapper()
if not current_week:
    logger.warning("Could not detect current week - aborting weekly update. "
                   "This may indicate the season hasn't started yet.")
    sys.exit(1)
```

The log line even says it's probably just the preseason, then exits 1 anyway. Reproduced locally: `is_active_season()` → `True`, `get_current_week_wrapper()` → `None`.

The real cost isn't the failed unit — it's that a month of guaranteed weekly failures makes a genuine problem invisible.

## Fix

That branch is unambiguously the not-yet-started case: the wrapper **re-raises** real API failures rather than returning `None`, and `main()` already catches those separately and exits 1. So it now skips gracefully with exit 0, matching how the off-season branch directly above already behaves.

Also tightened `not current_week` → `is None`, so a legitimate week 0 counts as a real week rather than a missing one.

## Tests

`test_no_current_week_exits_with_error` asserted `exit(1)` — it encoded the bug. Updated to assert the graceful skip, and added `test_week_detection_failure_still_exits_with_error` so the new path can't swallow genuine CFBD failures.

- [x] 802 passed (full suite, e2e excluded)
- [x] Ran the real script against the live API: **exit 0**, where prod exits 1 under identical conditions

## After deploy

```bash
sudo -u www-data git pull
sudo systemctl start cfb-weekly-update.service   # should now succeed
sudo systemctl status cfb-weekly-update.service
```

Note this is separate from #23. That one fixed what happens *after* the checks pass; this fixes the check that was preventing the run from ever getting there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)