### PR TITLE
docs: make cron the single weekly scheduler and say so

### DIFF
--- a/deploy/cfb-weekly-update.timer
+++ b/deploy/cfb-weekly-update.timer
@@ -1,3 +1,12 @@
+# DISABLED — do not enable. Cron runs utilities/weekly_update.sh, which is the
+# one weekly scheduler. This timer drives scripts/weekly_update.py, an earlier
+# and less capable implementation (no retries, no movement report, no
+# notifications). Both ran weekly for a period, duplicating import and snapshot
+# work. Kept for reference and for running the service by hand.
+# See docs/SEASON-RUNBOOK.md §3.
+#
+#   sudo systemctl disable --now cfb-weekly-update.timer
+
 [Unit]
 Description=CFB Rankings Weekly Update Timer
 Documentation=https://github.com/your-repo/cfb-rankings

--- a/deploy/logrotate-cfb-rankings
+++ b/deploy/logrotate-cfb-rankings
@@ -4,9 +4,11 @@
 # Verify:   sudo logrotate -d /etc/logrotate.d/cfb-rankings     # dry run
 # Force:    sudo logrotate -f /etc/logrotate.d/cfb-rankings     # rotate now
 #
-# Globs the whole directory because three different jobs write there:
-#   weekly.log         utilities/weekly_update.sh   (cron, user bdailey)
-#   weekly-update.log  scripts/weekly_update.py     (systemd timer, user www-data)
+# Globs the whole directory because several jobs write there:
+#   weekly.log         utilities/weekly_update.sh   (cron — the live scheduler)
+#   weekly-update.log  scripts/weekly_update.py     (manual runs only; the
+#                      systemd timer that drove this is disabled, see
+#                      docs/SEASON-RUNBOOK.md §3)
 #   update-games.log   scripts/update-production-data.sh (manual)
 
 /var/log/cfb-rankings/*.log {

--- a/docs/SEASON-RUNBOOK.md
+++ b/docs/SEASON-RUNBOOK.md
@@ -211,6 +211,9 @@ If predictions return an empty list, confirm games are in the DB and the season 
 
 ### Automated cron (runs at 9 AM every Monday)
 
+**Cron is the one scheduler.** Install under the crontab of the user that owns
+the deployment:
+
 ```
 0 9 * * 1 /var/www/cfb-rankings/utilities/weekly_update.sh >> /var/log/cfb-rankings/weekly.log 2>&1
 ```
@@ -218,10 +221,40 @@ If predictions return an empty list, confirm games are in the DB and the season 
 The script:
 1. Loads `CFBD_API_KEY` from `.env` if not already set
 2. Detects the active season from the DB
-3. Runs `import_real_data.py --season <SEASON>` to pull latest scores
+3. Runs `import_real_data.py --season <SEASON>` to pull latest scores (with retries)
 4. Processes all unprocessed games with scores through the ELO algorithm
 5. Saves `ranking_history` snapshots for each newly completed week
-6. Restarts the `cfb-rankings` service
+6. Computes the rank-movement report and sends Slack / email notifications
+7. Restarts the `cfb-rankings` service
+
+#### The systemd timer is disabled — do not re-enable it
+
+`deploy/cfb-weekly-update.{service,timer}` run `scripts/weekly_update.py`, an
+earlier and less capable implementation: no retries, no movement report, no
+notifications. For a period both it and cron ran weekly, each doing overlapping
+import and snapshot work. The timer is now disabled:
+
+```bash
+sudo systemctl disable --now cfb-weekly-update.timer
+```
+
+The unit files are kept because `weekly_update.py` still holds the pre-flight
+checks (quota guard, week detection) and is useful to run by hand. Running it on
+a schedule alongside cron is what caused the duplication.
+
+#### Caveat: cron runs as your user, not www-data
+
+The job writes to `/var/www/cfb-rankings` — including the database — as whoever
+owns the crontab. If that is not `www-data`, files gradually change owner and a
+later `sudo -u www-data git pull` fails with `unable to unlink old <file>:
+Permission denied`. Recover with:
+
+```bash
+sudo bash deploy/fix-permissions.sh
+```
+
+To stop it recurring, move the entry to www-data's crontab
+(`sudo crontab -u www-data -e`) so the job runs as the user that owns the files.
 
 ### Run the weekly update manually (if cron fails or needs re-running)
 


### PR DESCRIPTION
Two jobs were running the weekly update, each doing overlapping import and snapshot work:

| | `weekly_update.sh` (cron) | `weekly_update.py` (timer) |
|---|---|---|
| Import w/ retries | ✅ | single attempt |
| ELO processing + snapshots | ✅ explicit | via pipeline only |
| Rank movement report | ✅ | ❌ |
| Slack/email notifications | ✅ | ❌ |
| Pre-flight quota/week checks | ❌ | ✅ |

**Cron wins** — the shell script is the EPIC-035 deliverable and carries the features the Python path lacks. The timer is disabled on prod. Unit files are kept, because `weekly_update.py` still owns the pre-flight checks and is worth running by hand; running it *on a schedule* alongside cron is what caused the duplication.

Runbook §3 documented the cron line and said nothing about the timer at all, so the duplication was invisible from the docs.

## Also documented: the permissions drift

Cron runs as the crontab owner. `weekly.log` is owned by `bdailey`, so that's the user — and the job writes to `/var/www/cfb-rankings`, including the database. That gradually flips file ownership, which is what makes `sudo -u www-data git pull` fail with `unable to unlink old <file>: Permission denied`. That's happened at least once this week.

Runbook now carries the recovery (`deploy/fix-permissions.sh`) and the actual fix: move the entry to `sudo crontab -u www-data -e` so the job runs as the user that owns the files. Left as a documented recommendation rather than a change, since it's a decision about that box.

## Applied on prod

```bash
sudo systemctl disable --now cfb-weekly-update.timer
```

## Test plan

- [x] 802 passed (docs/config only; no code paths touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)