### PR TITLE
fix: declare the reported quota fields on APIUsageResponse

### DIFF
--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -429,6 +429,18 @@ class APIUsageResponse(BaseModel):
     top_endpoints: List[EndpointUsage]
     last_updated: datetime
 
+    # CFBD's own quota figures, from the x-calllimit-remaining header. Null until
+    # a call has been made this month with the header recorded, in which case the
+    # fields above are local estimates. Declared here because response_model
+    # silently drops undeclared keys — omitting them made the values invisible to
+    # every client even though the endpoint was computing them.
+    reported_remaining_calls: Optional[int] = None
+    reported_limit: Optional[int] = None
+    locally_counted_remaining: Optional[int] = None
+    # True when CFBD reports more calls left than CFBD_MONTHLY_LIMIT allows —
+    # the plan was upgraded and .env was not.
+    limit_config_stale: Optional[bool] = None
+
 
 # ============================================================================
 # Admin - Manual Update Trigger Schemas

--- a/tests/test_admin_endpoints.py
+++ b/tests/test_admin_endpoints.py
@@ -349,3 +349,55 @@ class TestAPIIntegration:
         assert status_response.status_code == 200
         assert status_response.json()["task_id"] == task_id
         assert status_response.json()["status"] in ["started", "running", "completed", "failed"]
+
+
+class TestAPIUsageResponseShape:
+    """The response model must not drop CFBD's reported quota fields.
+
+    get_monthly_usage() computed them correctly, but response_model silently
+    strips undeclared keys, so they never reached any client.
+    """
+
+    def test_reported_fields_survive_the_response_model(self):
+        from src.models.schemas import APIUsageResponse
+
+        payload = {
+            "month": "2026-08",
+            "total_calls": 346,
+            "monthly_limit": 30000,
+            "percentage_used": 3.39,
+            "remaining_calls": 28983,
+            "average_calls_per_day": 49.4,
+            "warning_level": None,
+            "top_endpoints": [],
+            "last_updated": datetime.utcnow(),
+            "reported_remaining_calls": 28983,
+            "reported_limit": 30000,
+            "locally_counted_remaining": 29654,
+            "limit_config_stale": False,
+        }
+
+        serialized = APIUsageResponse(**payload).model_dump()
+
+        assert serialized["reported_remaining_calls"] == 28983
+        assert serialized["reported_limit"] == 30000
+        assert serialized["locally_counted_remaining"] == 29654
+        assert serialized["limit_config_stale"] is False
+
+    def test_reported_fields_are_optional(self):
+        """Before any call carries the header, they are absent — not an error."""
+        from src.models.schemas import APIUsageResponse
+
+        serialized = APIUsageResponse(
+            month="2026-08",
+            total_calls=0,
+            monthly_limit=30000,
+            percentage_used=0.0,
+            remaining_calls=30000,
+            average_calls_per_day=0.0,
+            top_endpoints=[],
+            last_updated=datetime.utcnow(),
+        ).model_dump()
+
+        assert serialized["reported_remaining_calls"] is None
+        assert serialized["limit_config_stale"] is None


### PR DESCRIPTION
Follow-up to #24. The feature works on prod but its output is invisible.

`/api/admin/api-usage` declares `response_model=schemas.APIUsageResponse`, and Pydantic silently drops keys the model does not declare. `get_monthly_usage()` was returning `reported_remaining_calls`, `reported_limit`, `locally_counted_remaining` and `limit_config_stale`; none reached any client.

The computation was working — prod returns `percentage_used: 3.39`, which is `(30000 − 28983) / 30000`, i.e. derived from CFBD's reported figure. The old estimate would have said 1.15%. So the header is being read and used; only the reporting fields were stripped.

Declared them as Optional, since they are legitimately null until a call carries the header.

## Test plan

- [x] 2 new tests: fields survive the response model; fields are optional when unreported
- [x] 804 passed (full suite, e2e excluded)

## Deploy

```bash
sudo -u www-data git pull
sudo systemctl restart cfb-rankings
curl -s https://cfb.bdailey.com/api/admin/api-usage | python3 -m json.tool
```

Expect `reported_remaining_calls` to be populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)