### PR TITLE
feat: blend opponent-adjusted efficiency into the rating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,9 @@ CFBD_API_KEY=your_api_key_here
 DATABASE_URL=sqlite:///./cfb_rankings.db
 CFBD_MONTHLY_LIMIT=1000
 
+# EPIC-045: share of the rating that comes from opponent-adjusted efficiency
+# (CORE-style PPA). 0 disables the blend and restores pure ELO.
+EFFICIENCY_WEIGHT=0.25
+
 # For PostgreSQL (optional upgrade):
 # DATABASE_URL=postgresql://user:password@localhost/cfb_rankings

--- a/docs/EPIC-045-EFFICIENCY-BLEND.md
+++ b/docs/EPIC-045-EFFICIENCY-BLEND.md
@@ -1,0 +1,178 @@
+# EPIC-045: CORE-Style Efficiency Blend
+
+**Status:** ✅ Implemented (2026-08-09) — pending accuracy validation on live weeks
+**Priority:** Medium
+**Related:** EPIC-040 (per-player PPA for position strength — same data family, different grain)
+**Source:** [Introducing CORE college football ratings](https://radsportsanalytics.com/blog/introducing-core-college-football-ratings/)
+
+---
+
+## Problem Statement
+
+The Modified ELO rating is entirely **result-driven**: who won, by how much, against
+whom. It has no view of *how* a team won. A team that wins five one-score games
+against weak opponents rates identically to a team that wins five blowouts, and
+ELO cannot tell the difference between "good" and "lucky" until the luck runs out.
+
+CORE (Context & Opponent-Relative Efficiency) measures the other half: points
+created and allowed per play, adjusted first for situation (down, distance, field
+position, score, clock, home/away) and then for opponent strength across the whole
+schedule network. It is **efficiency-driven** and orthogonal to won-lost record.
+
+Blending the two gives a rating neither signal produces alone.
+
+---
+
+## What We Did *Not* Build
+
+CORE itself is published as a blog, not a feed — there is nothing to consume. And
+rebuilding it from play-level data would mean pulling every FBS scrimmage play,
+fitting a context model, and running a regularized joint offense/defense
+regression.
+
+CFBD already does both CORE stages and publishes the result at `GET /ppa/teams`:
+`offense.overall` and `defense.overall` are opponent-adjusted PPA per play. We
+consume those instead. One API call per import run.
+
+---
+
+## Design
+
+### Data
+
+`teams.offense_ppa` / `teams.defense_ppa` (nullable floats), refreshed by
+`src/importers/efficiency.py::import_team_efficiency` during every pipeline run.
+CFBD returns season-to-date values, so calling it in week N gives a point-in-time
+rating with no lookahead.
+
+### Scale — why standardizing, not a constant
+
+The obvious mapping is a fixed points-per-play constant: net PPA × ~70 plays/game
+converted at this model's own 100 ELO ≈ 7 points, giving ~1000 ELO per unit of net
+PPA. **Measured against real 2025 data, that is badly wrong for this system:**
+
+| | span across FBS |
+|---|---|
+| this model's ELO | 1482 → 1696 (~215 points) |
+| net PPA at 1000 ELO/unit | 1210 → 1840 (~630 points) |
+
+ELO here is far more compressed than the theoretical conversion assumes, so a fixed
+constant would have injected roughly 3× the intended spread — a nominal 25% weight
+behaving like a majority stake, and the blend would have thrown teams ±43 ranking
+places.
+
+Instead both signals are standardized. `efficiency_scale()` computes the FBS mean
+and standard deviation of ELO and of net PPA, and `efficiency_rating()` places each
+team on ELO's own mean and spread by z-score. One standard deviation of efficiency
+is worth exactly one standard deviation of ELO, `EFFICIENCY_WEIGHT` means what it
+says, and the mapping recalibrates itself as ELO disperses through the season.
+
+### The blend
+
+```
+effective_rating = (1 - w) * elo_rating + w * efficiency_rating
+```
+
+`w = EFFICIENCY_WEIGHT` (env var, default **0.25**). Falls back to pure ELO when:
+
+- `EFFICIENCY_WEIGHT` is 0 — the kill switch
+- the team has no PPA data (preseason, FCS, uncovered team)
+- the week is below `EFFICIENCY_MIN_WEEK` (4) — adjusted PPA is unstable on a
+  handful of games and CFBD's opponent adjustment has little schedule network yet
+- fewer than 20 rated teams exist, or either signal has no spread to standardize
+- anything at all goes wrong reading the population — the blend is an enhancement,
+  never a hard dependency of prediction
+
+### Where it applies
+
+| Path | Rating used |
+|---|---|
+| `save_weekly_rankings` → `ranking_history.elo_rating` | **blended** |
+| `_calculate_game_prediction` / `generate_predictions` | **blended** |
+| `create_and_store_prediction` → `*_elo_at_prediction` | **blended** (records what the prediction was made from) |
+| `process_game` ELO update math | **pure ELO** |
+| `calculate_sos` | **pure ELO** |
+| `save_final_season_snapshot` (week 999) → next-season carryover | **pure ELO** |
+
+`teams.elo_rating` is never written with a blended value. The blend is applied at
+read time only, so efficiency never compounds into itself through the update loop,
+and setting `EFFICIENCY_WEIGHT=0` reverts the system completely with no data
+repair. Rankings pick the blend up for free because they already read from
+`ranking_history`.
+
+---
+
+## Observed Effect (2025 final, w=0.25)
+
+Efficiency span lands at 1477 → 1703 against ELO's 1482 → 1696 — matched, as
+intended. Movement is a reorder, not a rescale: ±25 ranking places at the extremes,
+a few places inside the top 25.
+
+Up: Ohio State, Indiana, Texas Tech, Utah — efficiency stronger than record.
+Down: LSU, Texas, Alabama — record stronger than efficiency.
+
+---
+
+## Backtest
+
+`scripts/backtest_efficiency_blend.py` replays a season week by week against a
+throwaway copy of the database: at week N it predicts every game from ELO replayed
+over weeks 1..N-1 and efficiency through week N-1, then processes week N and
+advances. No lookahead.
+
+`/ppa/teams` cannot be queried retroactively — it only ever returns today's
+season-to-date numbers — so the harness rebuilds weekly efficiency from
+`/ppa/games` (one API call per season, cached to `data/`, so re-runs cost nothing).
+The proxy is the plain running mean of per-game net PPA, which correlates **0.987**
+with CFBD's adjusted values over 2025 at near-identical spread (sd 0.137 vs 0.132).
+Refitting CORE's opponent adjustment scored *worse* (0.94–0.98): at full season FBS
+schedules balance out enough that the adjustment is a small correction. Since the
+blend standardizes to z-scores, only correlation matters.
+
+### Results — 2024 + 2025, 1536 games
+
+Pure ELO baseline: accuracy **0.6927**, Brier **0.1948**.
+
+| w | acc (min_wk 4) | Brier (min_wk 4) |
+|---|---|---|
+| 0.00 | 0.6927 | 0.1948 |
+| 0.10 | 0.6992 | 0.1934 |
+| 0.15 | 0.6999 | 0.1928 |
+| **0.20** | **0.7005** | 0.1923 |
+| 0.25 | 0.6986 | 0.1919 |
+| 0.30 | 0.6992 | 0.1915 |
+| 0.40 | 0.6940 | 0.1912 |
+| 0.50 | 0.6960 | 0.1913 |
+
+The blend beats pure ELO on Brier at **every** weight and every gate tested. Gains
+are real but modest: about +0.8pp accuracy (~12 games in 1536) and ~1.5% Brier
+reduction at the peak.
+
+Brier keeps improving past w=0.30, but that is entirely a 2024 effect — in 2025,
+w≥0.40 *reduces* accuracy (0.7093 at w=0.50 vs 0.7187 baseline). The seasons only
+agree in the 0.10–0.30 band, so the high end is not trustworthy. **w=0.20–0.25 is
+the robust choice**; the shipped default of 0.25 sits inside it and needs no change.
+
+### The week gate: keep it at 4
+
+Efficiency ordering is unstable early — through week 4 it correlates only 0.73 with
+where it ends up, not reaching 0.9 until week 9. That argued for raising
+`EFFICIENCY_MIN_WEEK`. **The backtest says otherwise:** `min_week=4` matches or
+beats 6, 8 and 10 at every weight, and 10 is consistently the worst. Noisy early
+efficiency still carries more information than the preseason-dominated ELO it is
+being blended against. The gate stays at 4.
+
+---
+
+## Open Items
+
+- **Forward validation still matters.** The backtest rests on two seasons and on a
+  proxy validated only at full-season granularity — there is no historical CFBD
+  snapshot to check the week-6 proxy against, and unbalanced early schedules are
+  exactly where opponent adjustment earns its keep. Keep tracking
+  `predictions.was_correct` and Brier on live weeks; production uses the real
+  adjusted `/ppa/teams` values, which should be no worse than the proxy.
+- **Tuning knob.** `EFFICIENCY_WEIGHT` is env-driven so it can move without a
+  redeploy as live accuracy accumulates.
+- Efficiency is not surfaced in the API or frontend yet. The columns are there if
+  a team-detail offense/defense split is wanted later.

--- a/migrations/migrate_add_team_efficiency.py
+++ b/migrations/migrate_add_team_efficiency.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Database Migration: Add efficiency columns to teams
+
+Adds the EPIC-045 CORE-style efficiency columns to the existing teams table:
+    - offense_ppa (FLOAT)  opponent-adjusted offensive PPA per play, NULL until imported
+    - defense_ppa (FLOAT)  opponent-adjusted defensive PPA allowed per play
+
+Idempotent: skips columns that already exist. Safe to run multiple times.
+
+Rollback: columns are nullable; with EFFICIENCY_WEIGHT=0 they are ignored entirely,
+so leaving them in place is harmless.
+
+Part of: EPIC-045 (CORE-style efficiency blend) - Story 45.2
+"""
+
+import sqlite3
+import sys
+
+COLUMNS = [
+    ("offense_ppa", "FLOAT"),
+    ("defense_ppa", "FLOAT"),
+]
+
+
+def migrate(db_path: str = "cfb_rankings.db") -> int:
+    print("=" * 70)
+    print("MIGRATION: Add efficiency columns to teams (EPIC-045)")
+    print("=" * 70)
+    try:
+        conn = sqlite3.connect(db_path)
+        cur = conn.cursor()
+        for name, coltype in COLUMNS:
+            try:
+                cur.execute(f"ALTER TABLE teams ADD COLUMN {name} {coltype}")
+                print(f"✓ Added column {name} {coltype}")
+            except sqlite3.OperationalError as e:
+                if "duplicate column name" in str(e).lower():
+                    print(f"⚠️  Column '{name}' already exists — skipping")
+                else:
+                    raise
+        conn.commit()
+        conn.close()
+        print("\n✓ Migration complete")
+        return 0
+    except sqlite3.OperationalError as e:
+        print(f"❌ Migration failed: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(migrate())

--- a/scripts/backtest_efficiency_blend.py
+++ b/scripts/backtest_efficiency_blend.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Backtest the EPIC-045 efficiency blend to tune EFFICIENCY_WEIGHT / EFFICIENCY_MIN_WEEK.
+
+Replays a season week by week against a throwaway copy of the database. For each
+week N it predicts every game using only information available before that week
+was played — ELO from replaying weeks 1..N-1, efficiency from PPA through
+week N-1 — then processes week N and moves on. No lookahead anywhere.
+
+Efficiency source
+-----------------
+Production reads CFBD's opponent-adjusted ``/ppa/teams``, which only ever returns
+*today's* season-to-date values; there is no way to ask it what a team looked like
+in week 6 of a past season. So the backtest reconstructs week-by-week efficiency
+from ``/ppa/games`` (one API call per season, cached to data/) as the running mean
+of per-game net PPA.
+
+That proxy was validated against CFBD's own adjusted numbers for 2025: the plain
+running mean correlates **0.987** with ``/ppa/teams``, with near-identical spread
+(sd 0.137 vs 0.132). Refitting CORE's opponent adjustment scored *worse* (0.94-0.98)
+— at full season, FBS schedules balance out enough that the adjustment is a small
+correction. Since the blend standardizes both signals to z-scores, only the
+correlation matters, not the scale.
+
+Known limitation: that 0.987 is a full-season comparison. There is no historical
+CFBD snapshot to validate the proxy at week 6, and unbalanced early schedules are
+exactly where opponent adjustment earns its keep — so treat early-week results as
+softer evidence than late-week ones.
+
+Usage:
+    python3 scripts/backtest_efficiency_blend.py
+    python3 scripts/backtest_efficiency_blend.py --seasons 2025 --weights 0 0.25 0.5
+"""
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv()
+
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from src.core import ranking_service as rs  # noqa: E402
+from src.core.ranking_service import RankingService, blend_rating  # noqa: E402
+from src.integrations.cfbd_client import CFBDClient  # noqa: E402
+from src.models.models import Game, Team  # noqa: E402
+
+# Regular season only. /ppa/games numbers postseason rounds on its own scheme,
+# which does not line up with the games table's weeks 16-19.
+MAX_WEEK = 15
+
+DEFAULT_WEIGHTS = [0.0, 0.10, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50]
+DEFAULT_MIN_WEEKS = [4, 6, 8, 10]
+
+# Mirrors _calculate_game_prediction; see that function for the derivation.
+HOME_FIELD_ADVANTAGE = 65
+RATING_SCALE = 400
+POINTS_PER_100_ELO = 7.0
+
+
+def load_ppa_games(year: int, cache_dir: Path) -> list:
+    """Fetch /ppa/games for a season, caching so re-runs cost no API calls."""
+    cache = cache_dir / f"ppa_games_{year}.json"
+    if cache.exists():
+        print(f"  using cached {cache.relative_to(project_root)}")
+        return json.loads(cache.read_text())
+
+    api_key = os.getenv("CFBD_API_KEY")
+    if not api_key:
+        sys.exit("ERROR: CFBD_API_KEY not set and no cache available")
+
+    print(f"  fetching /ppa/games for {year} (1 API call)...")
+    rows = CFBDClient(api_key)._get("/ppa/games", params={"year": year})
+    if not rows:
+        sys.exit(f"ERROR: no PPA game data returned for {year}")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(rows))
+    print(f"  cached {len(rows)} rows to {cache.relative_to(project_root)}")
+    return rows
+
+
+def build_weekly_efficiency(ppa_rows: list) -> dict:
+    """{week: {team: (mean_off_ppa, mean_def_ppa)}} using games strictly before `week`.
+
+    FBS-vs-FBS only, matching what CORE counts.
+    """
+    fbs = {r["team"] for r in ppa_rows}
+    by_week = defaultdict(list)
+    for r in ppa_rows:
+        if r["seasonType"] != "regular" or r["opponent"] not in fbs:
+            continue
+        off = (r.get("offense") or {}).get("overall")
+        deff = (r.get("defense") or {}).get("overall")
+        if off is None or deff is None:
+            continue
+        by_week[r["week"]].append((r["team"], off, deff))
+
+    running = defaultdict(list)
+    out = {}
+    for week in range(1, MAX_WEEK + 2):
+        # snapshot BEFORE folding in this week's games
+        out[week] = {
+            t: (statistics.fmean(o for o, _ in v), statistics.fmean(d for _, d in v))
+            for t, v in running.items()
+            if len(v) >= 2  # one game is noise, not a rating
+        }
+        for team, off, deff in by_week.get(week, []):
+            running[team].append((off, deff))
+    return out
+
+
+def replay_season(db_path: Path, season: int, weekly_eff: dict) -> list:
+    """Replay a season point-in-time, returning one record per predicted game.
+
+    Each record holds the pure ELO and efficiency rating that were knowable before
+    kickoff, so the weight sweep afterwards is pure arithmetic — the expensive
+    replay happens once.
+    """
+    engine = create_engine(f"sqlite:///{db_path}")
+    session = sessionmaker(bind=engine)()
+    service = RankingService(session)
+
+    # Rewind: preseason ratings, and mark the season's games unplayed
+    service.reset_season(season)
+    session.query(Game).filter(Game.season == season).update({Game.is_processed: False})
+    session.commit()
+
+    weeks = sorted(
+        w[0]
+        for w in session.query(Game.week)
+        .filter(Game.season == season, Game.week <= MAX_WEEK)
+        .distinct()
+        .all()
+    )
+
+    records = []
+    for week in weeks:
+        # Efficiency as known before this week kicked off
+        eff_for_week = weekly_eff.get(week, {})
+        for team in session.query(Team).all():
+            vals = eff_for_week.get(team.name)
+            team.offense_ppa, team.defense_ppa = vals if vals else (None, None)
+        session.commit()
+
+        scale = rs.efficiency_scale(session)
+
+        games = (
+            session.query(Game)
+            .filter(
+                Game.season == season,
+                Game.week == week,
+                Game.excluded_from_rankings == False,  # noqa: E712
+            )
+            .all()
+        )
+
+        for game in games:
+            if game.home_score == 0 and game.away_score == 0:
+                continue  # unplayed
+            home, away = game.home_team, game.away_team
+            if not home or not away:
+                continue
+
+            records.append(
+                {
+                    "week": week,
+                    "neutral": bool(game.is_neutral_site),
+                    "home_elo": home.elo_rating,
+                    "away_elo": away.elo_rating,
+                    "home_eff": rs.efficiency_rating(home, scale) if scale else None,
+                    "away_eff": rs.efficiency_rating(away, scale) if scale else None,
+                    "home_score": game.home_score,
+                    "away_score": game.away_score,
+                }
+            )
+
+        # Advance state past this week
+        for game in games:
+            if game.home_score == 0 and game.away_score == 0:
+                continue
+            try:
+                service.process_game(game)
+            except ValueError:
+                continue  # invalid game for ranking purposes; skip like production does
+
+    session.close()
+    return records
+
+
+def score(records: list, weight: float, min_week: int) -> dict:
+    """Accuracy, Brier score and margin error for one (weight, min_week) setting."""
+    correct = brier = margin_err = 0.0
+    n = 0
+    for r in records:
+        home = blend_rating(r["home_elo"], r["home_eff"], weight, r["week"], min_week)
+        away = blend_rating(r["away_elo"], r["away_eff"], weight, r["week"], min_week)
+
+        diff = (home + (0 if r["neutral"] else HOME_FIELD_ADVANTAGE)) - away
+        home_wp = 1 / (1 + 10 ** (-diff / RATING_SCALE))
+
+        home_won = r["home_score"] > r["away_score"]
+        if r["home_score"] == r["away_score"]:
+            continue  # ties are not predictable either way
+
+        n += 1
+        correct += (home_wp > 0.5) == home_won
+        brier += (home_wp - (1.0 if home_won else 0.0)) ** 2
+        predicted_margin = (diff / 100) * POINTS_PER_100_ELO
+        margin_err += abs(predicted_margin - (r["home_score"] - r["away_score"]))
+
+    if n == 0:
+        return {"n": 0}
+    return {
+        "n": n,
+        "accuracy": correct / n,
+        "brier": brier / n,
+        "margin_mae": margin_err / n,
+    }
+
+
+def main():
+    # Replaying a season re-derives every preseason rating, which logs per team.
+    logging.getLogger("src").setLevel(logging.ERROR)
+
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--seasons", type=int, nargs="+", default=[2024, 2025])
+    parser.add_argument("--weights", type=float, nargs="+", default=DEFAULT_WEIGHTS)
+    parser.add_argument("--min-weeks", type=int, nargs="+", default=DEFAULT_MIN_WEEKS)
+    parser.add_argument("--db", default=str(project_root / "cfb_rankings.db"))
+    args = parser.parse_args()
+
+    source_db = Path(args.db)
+    if not source_db.exists():
+        sys.exit(f"ERROR: database not found: {source_db}")
+
+    all_records = []
+    tmpdir = Path(tempfile.mkdtemp(prefix="blend-backtest-"))
+    try:
+        for season in args.seasons:
+            print(f"\n{'=' * 70}\nSeason {season}\n{'=' * 70}")
+            ppa_rows = load_ppa_games(season, project_root / "data")
+            weekly_eff = build_weekly_efficiency(ppa_rows)
+
+            # Replay against a copy — the real database is never touched
+            work_db = tmpdir / f"backtest_{season}.db"
+            shutil.copy(source_db, work_db)
+
+            print("  replaying season...")
+            records = replay_season(work_db, season, weekly_eff)
+            covered = sum(1 for r in records if r["home_eff"] is not None)
+            print(f"  {len(records)} games predicted, {covered} with efficiency data")
+            all_records.append((season, records))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    combined = [r for _, recs in all_records for r in recs]
+    for label, records in [(f"{s}", r) for s, r in all_records] + [("ALL", combined)]:
+        if len(all_records) == 1 and label == "ALL":
+            continue
+        print(f"\n{'=' * 70}\n{label}: accuracy / Brier / margin MAE\n{'=' * 70}")
+        header = "  w     " + "".join(f"{'min_wk ' + str(m):>22}" for m in args.min_weeks)
+        print(header)
+        baseline = score(records, 0.0, 99)
+        print(f"  pure ELO baseline: n={baseline['n']} acc={baseline['accuracy']:.4f} "
+              f"brier={baseline['brier']:.4f} mae={baseline['margin_mae']:.2f}")
+        for w in args.weights:
+            cells = []
+            for m in args.min_weeks:
+                s = score(records, w, m)
+                delta = s["accuracy"] - baseline["accuracy"]
+                cells.append(f"{s['accuracy']:.4f}/{s['brier']:.4f}/{delta:+.4f}".rjust(22))
+            print(f"  {w:<6.2f}" + "".join(cells))
+
+        best = max(
+            ((w, m, score(records, w, m)) for w in args.weights for m in args.min_weeks),
+            key=lambda x: -x[2]["brier"],
+        )
+        print(f"\n  best Brier: w={best[0]} min_week={best[1]} "
+              f"brier={best[2]['brier']:.4f} acc={best[2]['accuracy']:.4f} "
+              f"(baseline brier={baseline['brier']:.4f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -34,15 +34,185 @@ Note:
 
 import logging
 import math
+import os
+import statistics
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, object_session
 
 logger = logging.getLogger(__name__)
 
 from src.models.models import ConferenceType, Game, Prediction, RankingHistory, Season, Team
+
+# ── EPIC-045: CORE-style efficiency blend ────────────────────────────────────
+# ELO is result-driven (who won, by how much). Opponent-adjusted PPA is
+# efficiency-driven (how many points per play a team creates and allows). They
+# disagree about teams that keep winning close games against weak opponents, so
+# blending the two produces a rating neither signal gives alone.
+#
+# The two signals live on different scales, and the mismatch is not small: over
+# 2025 this model's FBS ELO spans ~215 points while net PPA spans ~0.63/play.
+# Converting PPA with a fixed points-per-play constant therefore injects far more
+# spread than the blend weight advertises. Instead both signals are standardized
+# to z-scores and efficiency is expressed on ELO's own mean and spread, so
+# EFFICIENCY_WEIGHT means what it says and the mapping recalibrates itself as
+# ELO disperses over the course of a season.
+
+# How much of the final rating comes from efficiency. Tunable without a redeploy;
+# EFFICIENCY_WEIGHT=0 disables the blend entirely and restores pure ELO.
+EFFICIENCY_WEIGHT = float(os.getenv("EFFICIENCY_WEIGHT", "0.25"))
+
+# Adjusted PPA is unstable on a handful of games, and CFBD's opponent adjustment
+# has little schedule network to work with early. Below this week, pure ELO.
+EFFICIENCY_MIN_WEEK = 4
+
+# Standardizing needs enough teams for the mean/stdev to mean anything.
+EFFICIENCY_MIN_TEAMS = 20
+
+
+def net_ppa(team: Team) -> Optional[float]:
+    """Net opponent-adjusted PPA per play (offense minus defense allowed)."""
+    if team.offense_ppa is None or team.defense_ppa is None:
+        return None
+    return team.offense_ppa - team.defense_ppa
+
+
+def efficiency_scale(db: Session) -> Optional[Tuple[float, float, float, float]]:
+    """Population stats needed to express efficiency on the ELO scale.
+
+    Computed over FBS teams that have efficiency data, so the mapping tracks
+    however wide or compressed ELO happens to be at this point in the season.
+
+    Args:
+        db: SQLAlchemy session
+
+    Returns:
+        (mean_elo, stdev_elo, mean_net, stdev_net), or None if there is not
+        enough data to standardize — in which case callers fall back to pure ELO.
+    """
+    # The blend is an enhancement, never a hard dependency: any problem reading
+    # the population falls back to pure ELO rather than breaking predictions.
+    try:
+        teams = [
+            t
+            for t in db.query(Team).filter(Team.is_fcs == False).all()  # noqa: E712
+            if net_ppa(t) is not None
+        ]
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(f"Could not compute efficiency scale, falling back to pure ELO: {e}")
+        return None
+
+    if len(teams) < EFFICIENCY_MIN_TEAMS:
+        return None
+
+    elos = [t.elo_rating for t in teams]
+    nets = [net_ppa(t) for t in teams]
+    stdev_elo = statistics.stdev(elos)
+    stdev_net = statistics.stdev(nets)
+    if stdev_elo <= 0 or stdev_net <= 0:
+        return None
+
+    return statistics.fmean(elos), stdev_elo, statistics.fmean(nets), stdev_net
+
+
+def efficiency_rating(team: Team, scale: Tuple[float, float, float, float]) -> Optional[float]:
+    """Express a team's efficiency on the ELO scale.
+
+    Args:
+        team: Team with offense_ppa / defense_ppa populated by the efficiency import
+        scale: Output of :func:`efficiency_scale`
+
+    Returns:
+        Efficiency-implied ELO rating, or None if the team has no PPA data
+        (preseason, FCS opponents, or a team CFBD does not cover).
+    """
+    net = net_ppa(team)
+    if net is None:
+        return None
+
+    mean_elo, stdev_elo, mean_net, stdev_net = scale
+    return mean_elo + ((net - mean_net) / stdev_net) * stdev_elo
+
+
+def blend_rating(
+    elo: float,
+    eff: Optional[float],
+    weight: float = None,
+    week: Optional[int] = None,
+    min_week: int = None,
+) -> float:
+    """Combine an ELO rating with an efficiency rating on the same scale.
+
+    The single place the blend arithmetic lives, so that tuning tools
+    (scripts/backtest_efficiency_blend.py) and production cannot drift apart.
+
+    Args:
+        elo: Pure ELO rating
+        eff: Efficiency rating on the ELO scale, or None if unavailable
+        weight: Efficiency share; defaults to EFFICIENCY_WEIGHT
+        week: Season week, or None to skip the early-season gate
+        min_week: Earliest week the blend applies; defaults to EFFICIENCY_MIN_WEEK
+
+    Returns:
+        Blended rating, or ``elo`` unchanged whenever the blend does not apply
+    """
+    weight = EFFICIENCY_WEIGHT if weight is None else weight
+    min_week = EFFICIENCY_MIN_WEEK if min_week is None else min_week
+
+    if weight <= 0 or eff is None:
+        return elo
+    if week is not None and week < min_week:
+        return elo
+
+    return (1 - weight) * elo + weight * eff
+
+
+def effective_rating(
+    team: Team,
+    week: Optional[int] = None,
+    scale: Optional[Tuple[float, float, float, float]] = None,
+) -> float:
+    """Return the rating used for rankings and predictions.
+
+    Blends the team's stored ELO with its efficiency-implied rating. Falls back
+    to pure ELO when efficiency data is missing, the blend is switched off, or
+    the season is too young for adjusted PPA to be meaningful.
+
+    The blend is deliberately applied at read time. ``teams.elo_rating`` stays a
+    pure ELO value so that game-by-game updates never compound efficiency into
+    themselves, and setting EFFICIENCY_WEIGHT back to 0 fully reverts the system
+    with no data repair.
+
+    Args:
+        team: Team to rate
+        week: Season week the rating is for; None skips the early-season gate
+            (used for end-of-season snapshots, where the sample is complete)
+        scale: Precomputed :func:`efficiency_scale` output. Pass it when rating
+            many teams at once; otherwise it is derived from the team's session.
+
+    Returns:
+        Blended rating on the ELO scale
+    """
+    if EFFICIENCY_WEIGHT <= 0:
+        return team.elo_rating
+
+    if week is not None and week < EFFICIENCY_MIN_WEEK:
+        return team.elo_rating
+
+    if net_ppa(team) is None:
+        return team.elo_rating
+
+    if scale is None:
+        db = object_session(team)
+        if db is None:
+            return team.elo_rating
+        scale = efficiency_scale(db)
+        if scale is None:
+            return team.elo_rating
+
+    return blend_rating(team.elo_rating, efficiency_rating(team, scale), week=week)
 
 
 class RankingService:
@@ -922,8 +1092,16 @@ class RankingService:
             RankingHistory.season == season, RankingHistory.week == week
         ).delete()
 
-        # Build rankings from current teams table state (not from ranking_history)
-        teams = self.db.query(Team).order_by(Team.elo_rating.desc()).all()
+        # Build rankings from current teams table state (not from ranking_history).
+        # EPIC-045: the snapshot stores the blended rating, so rankings and their
+        # history reflect efficiency without any read-path change. Sorting happens
+        # in Python because the blend is not expressible in SQL.
+        scale = efficiency_scale(self.db)
+        teams = sorted(
+            self.db.query(Team).all(),
+            key=lambda t: effective_rating(t, week, scale),
+            reverse=True,
+        )
 
         for rank, team in enumerate(teams, start=1):
             # Calculate season-specific wins/losses
@@ -937,7 +1115,7 @@ class RankingService:
                 week=week,
                 season=season,
                 rank=rank,
-                elo_rating=team.elo_rating,
+                elo_rating=effective_rating(team, week, scale),  # EPIC-045: blended
                 wins=wins,  # Season-specific wins
                 losses=losses,  # Season-specific losses
                 sos=sos,
@@ -1049,6 +1227,7 @@ def generate_predictions(
     # Execute query
     games = query.all()
     predictions = []
+    scale = efficiency_scale(db)  # EPIC-045: compute once for the whole slate
 
     for game in games:
         # Get team data
@@ -1060,7 +1239,7 @@ def generate_predictions(
             continue
 
         # Generate prediction
-        prediction = _calculate_game_prediction(game, home_team, away_team)
+        prediction = _calculate_game_prediction(game, home_team, away_team, scale)
         predictions.append(prediction)
 
     return predictions
@@ -1149,16 +1328,25 @@ def _validate_prediction_teams(home_team: Team, away_team: Team) -> bool:
     return True
 
 
-def _calculate_game_prediction(game: Game, home_team: Team, away_team: Team) -> Dict[str, Any]:
+def _calculate_game_prediction(
+    game: Game,
+    home_team: Team,
+    away_team: Team,
+    scale: Optional[Tuple[float, float, float, float]] = None,
+) -> Dict[str, Any]:
     """
     Calculate prediction for a single game.
 
     Uses standard ELO formula for win probability and estimates scores
     based on rating difference.
     """
+    # EPIC-045: predict off the blended rating, not raw ELO
+    home_elo = effective_rating(home_team, game.week, scale)
+    away_elo = effective_rating(away_team, game.week, scale)
+
     # Apply home field advantage (unless neutral site)
-    home_rating = home_team.elo_rating + (0 if game.is_neutral_site else 65)
-    away_rating = away_team.elo_rating
+    home_rating = home_elo + (0 if game.is_neutral_site else 65)
+    away_rating = away_elo
 
     # Calculate win probability (standard ELO formula)
     rating_diff = home_rating - away_rating
@@ -1206,8 +1394,8 @@ def _calculate_game_prediction(game: Game, home_team: Team, away_team: Team) -> 
         "home_win_probability": round(home_win_prob * 100, 1),
         "away_win_probability": round(away_win_prob * 100, 1),
         "confidence": confidence,
-        "home_team_rating": home_team.elo_rating,
-        "away_team_rating": away_team.elo_rating,
+        "home_team_rating": home_elo,
+        "away_team_rating": away_elo,
     }
 
 
@@ -1394,8 +1582,9 @@ def create_and_store_prediction(db: Session, game: Game) -> Optional[Prediction]
             if prediction_data["predicted_winner_id"] == home_team.id
             else prediction_data["away_win_probability"] / 100.0
         ),
-        home_elo_at_prediction=home_team.elo_rating,
-        away_elo_at_prediction=away_team.elo_rating,
+        # EPIC-045: record the rating the prediction was actually made from
+        home_elo_at_prediction=prediction_data["home_team_rating"],
+        away_elo_at_prediction=prediction_data["away_team_rating"],
         was_correct=None,  # Will be set when game completes
     )
 

--- a/src/importers/__init__.py
+++ b/src/importers/__init__.py
@@ -14,6 +14,7 @@ from src.importers.common import (
     parse_game_date,
     resolve_final_week,
 )
+from src.importers.efficiency import import_team_efficiency
 from src.importers.games import import_games
 from src.importers.pipeline import main
 from src.importers.polls import import_ap_poll_rankings
@@ -43,6 +44,7 @@ __all__ = [
     "import_conference_championships",
     "import_games",
     "import_playoff_games",
+    "import_team_efficiency",
     "import_teams",
     "main",
     "parse_game_date",

--- a/src/importers/efficiency.py
+++ b/src/importers/efficiency.py
@@ -1,0 +1,54 @@
+"""Team efficiency import from the CFBD API (EPIC-045).
+
+Pulls opponent-adjusted team PPA — the CORE-style efficiency signal — and stores
+it on the teams table. One API call per run; the rating blend in
+``src.core.ranking_service`` reads it from there.
+"""
+
+from src.integrations.cfbd_client import CFBDClient
+from src.models.models import Team
+
+
+def import_team_efficiency(cfbd: CFBDClient, db, year: int) -> int:
+    """Refresh offense_ppa / defense_ppa for every team from CFBD.
+
+    Values are season-to-date, so running this weekly keeps the blend current
+    without any lookahead. Teams missing from the response (FCS, or not yet
+    covered this season) keep whatever they had; the blend falls back to pure
+    ELO when the columns are NULL.
+
+    Args:
+        cfbd: Authenticated CFBD client
+        db: SQLAlchemy session
+        year: Season year
+
+    Returns:
+        Number of teams updated
+    """
+    print(f"\nImporting team efficiency (adjusted PPA) for {year}...")
+
+    ppa_data = cfbd.get_team_ppa_season(year)
+    if not ppa_data:
+        print("⚠️  No team PPA available — leaving existing efficiency values in place")
+        return 0
+
+    teams_by_name = {t.name: t for t in db.query(Team).all()}
+    updated = 0
+
+    for row in ppa_data:
+        team = teams_by_name.get(row.get("team"))
+        if team is None:
+            continue
+
+        offense = (row.get("offense") or {}).get("overall")
+        defense = (row.get("defense") or {}).get("overall")
+        if offense is None or defense is None:
+            continue
+
+        team.offense_ppa = offense
+        team.defense_ppa = defense
+        updated += 1
+
+    db.commit()
+    print(f"✓ Updated efficiency for {updated} teams")
+    return updated

--- a/src/importers/pipeline.py
+++ b/src/importers/pipeline.py
@@ -15,6 +15,7 @@ except (PermissionError, FileNotFoundError):
 
 from src.core.ranking_service import RankingService
 from src.importers.common import resolve_final_week
+from src.importers.efficiency import import_team_efficiency
 from src.importers.games import import_games
 from src.importers.postseason import (
     import_bowl_games,
@@ -237,6 +238,10 @@ Examples:
     # Update season current week to actual max
     season_obj.current_week = final_week
     db.commit()
+
+    # EPIC-045: refresh adjusted PPA before snapshotting, so the ratings written
+    # to ranking_history reflect the efficiency blend for this week.
+    import_team_efficiency(cfbd, db, year=season)
 
     # Snapshot ONLY the latest week. save_weekly_rankings() writes the CURRENT
     # teams-table ratings under the week it is given, so looping it from week 1

--- a/src/integrations/cfbd_client.py
+++ b/src/integrations/cfbd_client.py
@@ -884,6 +884,55 @@ class CFBDClient:
 
         return result
 
+    def get_team_ppa_season(self, year: int, team: Optional[str] = None) -> List[Dict]:
+        """
+        Get opponent-adjusted team season PPA (Predicted Points Added per play).
+
+        This is the efficiency signal behind CORE-style ratings: CFBD has already
+        done both adjustment stages (situational context, then opponent strength
+        across the schedule network), so we consume the adjusted numbers rather
+        than refitting them from play-level data.
+
+        In-season the endpoint returns season-to-date values, so calling it during
+        week N yields a point-in-time rating with no lookahead.
+
+        Part of: EPIC-045 (CORE-style efficiency blend) - Story 45.1
+
+        Args:
+            year: Season year (e.g., 2025)
+            team: Optional team name filter (e.g., "Georgia")
+
+        Returns:
+            List of team PPA dictionaries, each containing:
+                - team: str - CFBD team name
+                - conference: str
+                - offense: dict - includes "overall" (adjusted PPA per play, higher is better)
+                - defense: dict - includes "overall" (adjusted PPA allowed per play, lower is better)
+
+            Returns empty list if API call fails or no data available.
+
+        Example:
+            >>> client = CFBDClient()
+            >>> ppa = client.get_team_ppa_season(year=2025)
+            >>> net = ppa[0]["offense"]["overall"] - ppa[0]["defense"]["overall"]
+
+        Note:
+            - Automatically tracked via @track_api_usage decorator (through _get)
+            - Gracefully handles API errors by returning empty list
+            - API endpoint: GET /ppa/teams
+        """
+        params: Dict = {"year": year}
+        if team:
+            params["team"] = team
+
+        result = self._get("/ppa/teams", params=params)
+
+        if result is None:
+            logger.warning(f"Failed to fetch team PPA for year={year}, team={team}")
+            return []
+
+        return result
+
     def get_team_talent(self, year: int) -> List[Dict]:
         """
         Get team talent composite scores

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -91,6 +91,8 @@ class Team(Base):
         transfer_count: Number of incoming transfer players
         elo_rating: Current Modified ELO rating
         initial_rating: Preseason ELO rating (before any games)
+        offense_ppa: Opponent-adjusted offensive PPA per play (higher is better)
+        defense_ppa: Opponent-adjusted defensive PPA allowed per play (lower is better)
         wins: Cumulative win count (all seasons)
         losses: Cumulative loss count (all seasons)
         created_at: Record creation timestamp
@@ -139,6 +141,12 @@ class Team(Base):
     initial_rating = Column(Float, default=1500.0)  # Store preseason rating
     wins = Column(Integer, default=0)
     losses = Column(Integer, default=0)
+
+    # EPIC-045: CORE-style efficiency (opponent-adjusted PPA per play, season-to-date).
+    # NULL until the first efficiency import of a season; the rating blend falls
+    # back to pure ELO when either value is missing.
+    offense_ppa = Column(Float, nullable=True)
+    defense_ppa = Column(Float, nullable=True)
 
     # Metadata
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/tests/unit/test_efficiency_blend.py
+++ b/tests/unit/test_efficiency_blend.py
@@ -1,0 +1,250 @@
+"""Tests for the EPIC-045 CORE-style efficiency blend."""
+
+import pytest
+
+from src.core import ranking_service as rs
+from src.core.ranking_service import (
+    blend_rating,
+    effective_rating,
+    efficiency_rating,
+    efficiency_scale,
+    net_ppa,
+)
+from src.models.models import ConferenceType, Team
+
+# (mean_elo, stdev_elo, mean_net, stdev_net) — one stdev of efficiency is worth
+# one stdev of ELO, i.e. 50 points here.
+SCALE = (1500.0, 50.0, 0.0, 0.1)
+
+
+def make_team(name="Test", elo=1500.0, offense_ppa=None, defense_ppa=None):
+    return Team(
+        name=name,
+        conference=ConferenceType.POWER_5,
+        is_fcs=False,
+        elo_rating=elo,
+        offense_ppa=offense_ppa,
+        defense_ppa=defense_ppa,
+    )
+
+
+@pytest.fixture
+def blend_on(monkeypatch):
+    """Pin the blend weight so tests do not depend on the EFFICIENCY_WEIGHT env var."""
+    monkeypatch.setattr(rs, "EFFICIENCY_WEIGHT", 0.25)
+
+
+class TestNetPPA:
+    def test_none_without_both_halves(self):
+        assert net_ppa(make_team()) is None
+        assert net_ppa(make_team(offense_ppa=0.2)) is None
+        assert net_ppa(make_team(defense_ppa=0.0)) is None
+
+    def test_offense_minus_defense(self):
+        assert net_ppa(make_team(offense_ppa=0.25, defense_ppa=-0.10)) == pytest.approx(0.35)
+
+
+class TestBlendRating:
+    """The shared formula — production and the backtest harness both go through it."""
+
+    def test_weighted_average(self):
+        assert blend_rating(1700.0, 1500.0, weight=0.25, week=10, min_week=4) == pytest.approx(1650.0)
+
+    def test_missing_efficiency_returns_elo(self):
+        assert blend_rating(1700.0, None, weight=0.25, week=10, min_week=4) == 1700.0
+
+    def test_zero_weight_returns_elo(self):
+        assert blend_rating(1700.0, 1500.0, weight=0.0, week=10, min_week=4) == 1700.0
+
+    def test_week_gate(self):
+        assert blend_rating(1700.0, 1500.0, weight=0.25, week=3, min_week=4) == 1700.0
+        assert blend_rating(1700.0, 1500.0, weight=0.25, week=4, min_week=4) != 1700.0
+
+    def test_no_week_skips_the_gate(self):
+        assert blend_rating(1700.0, 1500.0, weight=0.25, min_week=99) == pytest.approx(1650.0)
+
+    def test_defaults_come_from_module_config(self, monkeypatch):
+        monkeypatch.setattr(rs, "EFFICIENCY_WEIGHT", 0.5)
+        monkeypatch.setattr(rs, "EFFICIENCY_MIN_WEEK", 7)
+        assert blend_rating(1700.0, 1500.0, week=10) == pytest.approx(1600.0)
+        assert blend_rating(1700.0, 1500.0, week=6) == 1700.0
+
+    def test_effective_rating_agrees_with_blend_rating(self, blend_on):
+        """effective_rating must be blend_rating plus data lookup, nothing more."""
+        team = make_team(elo=1700.0, offense_ppa=0.1, defense_ppa=0.0)
+        eff = efficiency_rating(team, SCALE)
+        assert effective_rating(team, 10, SCALE) == pytest.approx(
+            blend_rating(1700.0, eff, rs.EFFICIENCY_WEIGHT, 10, rs.EFFICIENCY_MIN_WEEK)
+        )
+
+
+class TestEfficiencyRating:
+    def test_average_efficiency_sits_at_mean_elo(self):
+        team = make_team(offense_ppa=0.1, defense_ppa=0.1)  # net 0.0 == mean_net
+        assert efficiency_rating(team, SCALE) == pytest.approx(1500.0)
+
+    def test_one_stdev_of_efficiency_is_one_stdev_of_elo(self):
+        team = make_team(offense_ppa=0.1, defense_ppa=0.0)  # net +0.1 == +1 sd
+        assert efficiency_rating(team, SCALE) == pytest.approx(1550.0)
+
+    def test_bad_efficiency_lands_below_the_mean(self):
+        team = make_team(offense_ppa=-0.1, defense_ppa=0.1)  # net -0.2 == -2 sd
+        assert efficiency_rating(team, SCALE) == pytest.approx(1400.0)
+
+    def test_returns_none_without_data(self):
+        assert efficiency_rating(make_team(), SCALE) is None
+
+
+class TestEfficiencyScale:
+    def test_none_when_too_few_teams(self, db_session):
+        for i in range(rs.EFFICIENCY_MIN_TEAMS - 1):
+            db_session.add(make_team(name=f"T{i}", elo=1500 + i, offense_ppa=i / 100, defense_ppa=0.0))
+        db_session.commit()
+        assert efficiency_scale(db_session) is None
+
+    def test_none_when_efficiency_has_no_spread(self, db_session):
+        for i in range(rs.EFFICIENCY_MIN_TEAMS + 5):
+            db_session.add(make_team(name=f"T{i}", elo=1500 + i, offense_ppa=0.1, defense_ppa=0.0))
+        db_session.commit()
+        assert efficiency_scale(db_session) is None
+
+    def test_computes_population_stats(self, db_session):
+        for i in range(40):
+            db_session.add(
+                make_team(name=f"T{i}", elo=1500 + i * 10, offense_ppa=i / 100, defense_ppa=0.0)
+            )
+        db_session.commit()
+
+        mean_elo, stdev_elo, mean_net, stdev_net = efficiency_scale(db_session)
+        assert mean_elo == pytest.approx(1695.0)
+        assert mean_net == pytest.approx(0.195)
+        assert stdev_elo > 0 and stdev_net > 0
+        # ELO stdev is 100x the net-PPA stdev here by construction (elo step 10,
+        # ppa step 0.01) — the mapping absorbs whatever the real ratio is.
+        assert stdev_elo == pytest.approx(stdev_net * 1000)
+
+    def test_ignores_fcs_and_teams_without_data(self, db_session):
+        for i in range(30):
+            db_session.add(
+                make_team(name=f"T{i}", elo=1500 + i * 10, offense_ppa=i / 100, defense_ppa=0.0)
+            )
+        fcs = make_team(name="FCS U", elo=1000, offense_ppa=-5.0, defense_ppa=5.0)
+        fcs.is_fcs = True
+        db_session.add(fcs)
+        db_session.add(make_team(name="No Data", elo=9999))
+        db_session.commit()
+
+        mean_elo, _, mean_net, _ = efficiency_scale(db_session)
+        assert mean_elo == pytest.approx(1645.0)  # neither outlier pulled the mean
+        assert mean_net == pytest.approx(0.145)
+
+
+class TestEffectiveRating:
+    def test_falls_back_to_elo_without_efficiency_data(self, blend_on):
+        team = make_team(elo=1700.0)
+        assert effective_rating(team, week=10, scale=SCALE) == 1700.0
+
+    def test_blends_elo_and_efficiency(self, blend_on):
+        # elo 1700, efficiency 1550 → 0.75 * 1700 + 0.25 * 1550
+        team = make_team(elo=1700.0, offense_ppa=0.1, defense_ppa=0.0)
+        assert effective_rating(team, week=10, scale=SCALE) == pytest.approx(1662.5)
+
+    def test_efficiency_can_drag_a_lucky_team_down(self, blend_on):
+        """The whole point: a high-ELO team with mediocre efficiency loses ground."""
+        lucky = make_team(elo=1800.0, offense_ppa=0.05, defense_ppa=0.05)
+        assert effective_rating(lucky, week=10, scale=SCALE) < lucky.elo_rating
+
+    def test_early_season_uses_pure_elo(self, blend_on):
+        team = make_team(elo=1700.0, offense_ppa=0.1, defense_ppa=0.0)
+        assert effective_rating(team, rs.EFFICIENCY_MIN_WEEK - 1, SCALE) == 1700.0
+        assert effective_rating(team, rs.EFFICIENCY_MIN_WEEK, SCALE) != 1700.0
+
+    def test_no_week_skips_the_early_season_gate(self, blend_on):
+        team = make_team(elo=1700.0, offense_ppa=0.1, defense_ppa=0.0)
+        assert effective_rating(team, scale=SCALE) == pytest.approx(1662.5)
+
+    def test_zero_weight_disables_the_blend(self, monkeypatch):
+        monkeypatch.setattr(rs, "EFFICIENCY_WEIGHT", 0.0)
+        team = make_team(elo=1700.0, offense_ppa=0.1, defense_ppa=0.0)
+        assert effective_rating(team, week=10, scale=SCALE) == 1700.0
+
+    def test_detached_team_without_scale_falls_back_to_elo(self, blend_on):
+        """No session to derive population stats from — must not raise."""
+        team = make_team(elo=1700.0, offense_ppa=0.1, defense_ppa=0.0)
+        assert effective_rating(team, week=10) == 1700.0
+
+    def test_derives_scale_from_the_teams_session(self, blend_on, db_session):
+        # efficiency runs opposite to ELO, so the blend must move the rating
+        for i in range(40):
+            db_session.add(
+                make_team(name=f"T{i}", elo=1500 + i * 10, offense_ppa=(40 - i) / 100, defense_ppa=0.0)
+            )
+        db_session.commit()
+
+        team = db_session.query(Team).filter(Team.name == "T39").first()
+        expected = effective_rating(team, 10, efficiency_scale(db_session))
+        assert effective_rating(team, week=10) == pytest.approx(expected)
+        assert effective_rating(team, week=10) != team.elo_rating
+
+    def test_blend_preserves_the_rating_spread(self, blend_on, db_session):
+        """Standardizing means the blend reorders teams without inflating the scale."""
+        import statistics
+
+        for i in range(60):
+            # ELO and efficiency deliberately disagree (efficiency runs backwards)
+            db_session.add(
+                make_team(name=f"T{i}", elo=1500 + i, offense_ppa=(60 - i) / 100, defense_ppa=0.0)
+            )
+        db_session.commit()
+
+        teams = db_session.query(Team).all()
+        scale = efficiency_scale(db_session)
+        before = statistics.stdev([t.elo_rating for t in teams])
+        after = statistics.stdev([effective_rating(t, 10, scale) for t in teams])
+
+        # A fixed points-per-play constant would blow this up; standardizing keeps
+        # the blended spread bounded by the inputs' own spread.
+        assert after <= before + 1e-6
+
+
+class TestEfficiencyImport:
+    def test_import_populates_ppa_columns(self, db_session):
+        from src.importers.efficiency import import_team_efficiency
+
+        db_session.add(make_team(name="Georgia"))
+        db_session.commit()
+
+        class FakeClient:
+            def get_team_ppa_season(self, year, team=None):
+                return [
+                    {
+                        "team": "Georgia",
+                        "offense": {"overall": 0.25},
+                        "defense": {"overall": -0.10},
+                    },
+                    {  # not in our DB — must be skipped, not crash
+                        "team": "Nowhere State",
+                        "offense": {"overall": 0.1},
+                        "defense": {"overall": 0.1},
+                    },
+                    {"team": "Georgia", "offense": None, "defense": None},  # malformed
+                ]
+
+        assert import_team_efficiency(FakeClient(), db_session, year=2025) == 1
+        team = db_session.query(Team).filter(Team.name == "Georgia").first()
+        assert team.offense_ppa == pytest.approx(0.25)
+        assert team.defense_ppa == pytest.approx(-0.10)
+
+    def test_empty_api_response_leaves_existing_values(self, db_session):
+        from src.importers.efficiency import import_team_efficiency
+
+        db_session.add(make_team(name="Georgia", offense_ppa=0.2, defense_ppa=0.0))
+        db_session.commit()
+
+        class EmptyClient:
+            def get_team_ppa_season(self, year, team=None):
+                return []
+
+        assert import_team_efficiency(EmptyClient(), db_session, year=2025) == 0
+        team = db_session.query(Team).filter(Team.name == "Georgia").first()
+        assert team.offense_ppa == pytest.approx(0.2)


### PR DESCRIPTION
ELO is result-driven and cannot tell a good team from a lucky one: five one-score wins over weak opponents rate the same as five blowouts. CORE-style efficiency (points created and allowed per play, adjusted for situation and opponent) measures the other half, and is orthogonal to won-lost record.

CFBD already runs both CORE adjustment stages and publishes the result at GET /ppa/teams, so consume that rather than refitting a context model and an opponent regression from play-level data. One API call per import run.

Scale: the textbook conversion (net PPA x ~70 plays / 7 points per 100 ELO) proved badly wrong for this system. Measured on 2025, our FBS ELO spans ~215 points while that constant implies ~630 -- a nominal 25% weight would have behaved like a majority stake and thrown teams +/-43 ranking places. Both signals are standardized instead, so one stdev of efficiency is worth one stdev of ELO, EFFICIENCY_WEIGHT means what it says, and the mapping recalibrates itself as ELO disperses through a season.

The blend is applied at read time only. teams.elo_rating stays pure ELO, so efficiency never compounds into itself through the update loop and EFFICIENCY_WEIGHT=0 reverts the system with no data repair. Rankings pick it up for free because they already read from ranking_history. Game processing, SOS and the next-season carryover all keep using raw ELO.

Backtested over 2024+2025 (1536 games) by replaying each season week by week against a throwaway database copy, with efficiency reconstructed from /ppa/games -- /ppa/teams cannot be queried retroactively. The blend beats pure ELO on Brier at every weight and gate tested; the peak is about +0.8pp accuracy and ~1.5% Brier reduction. The seasons only agree in the w=0.10-0.30 band, so 0.25 ships as the default. min_week=4 matched or beat 6/8/10 everywhere, despite early efficiency being noisy.