### PR TITLE
feat: seed the CFP bracket from a simulated season

### DIFF
--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -225,6 +225,27 @@
 .tkr-bracket-meta { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--fg3);
   text-transform: uppercase; text-align: right; line-height: 1.6; white-space: nowrap; }
 .bk-cols { display: flex; gap: 14px; min-height: 640px; overflow-x: auto; }
+
+/* Playoff odds strip: per-team probabilities from the season simulation.
+   Only rendered when the projection came from a Monte Carlo run. */
+.bk-odds { margin-top: 18px; border-top: 1px solid var(--line); padding-top: 14px; }
+.bk-odds.hidden { display: none; }
+.bk-odds-title { font-size: 13px; font-weight: 700; margin: 0 0 10px; letter-spacing: -0.01em; }
+.bk-odds-head, .bk-odds-row { display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono); font-size: 12px; padding: 3px 0; }
+.bk-odds-head { font-size: 9.5px; letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--fg3); border-bottom: 1px solid var(--line); padding-bottom: 6px; margin-bottom: 4px; }
+.bk-odds-row.out { color: var(--fg2); }
+.bk-odds-seed { width: 22px; text-align: right; color: var(--fg3); flex: none; }
+.bk-odds-name { flex: 1 1 auto; min-width: 84px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bk-odds-bar { flex: 2 1 90px; height: 6px; border-radius: 3px; background: var(--panel2); overflow: hidden; }
+.bk-odds-head .bk-odds-bar { background: none; }
+.bk-odds-bar i { display: block; height: 100%; border-radius: 3px; }
+.bk-odds-pct { width: 52px; text-align: right; font-weight: 700; flex: none; }
+.bk-odds-sub { width: 46px; text-align: right; color: var(--fg3); flex: none; }
+.bk-odds-split { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.05em;
+  text-transform: uppercase; color: var(--fg3); margin: 10px 0 4px;
+  border-top: 1px dashed var(--line); padding-top: 8px; }
 .bk-col { flex: 1 1 0; min-width: 152px; display: flex; flex-direction: column; }
 .bk-round { border-bottom: 1px solid var(--line); padding-bottom: 8px; margin-bottom: 10px; }
 .bk-round-t { font-family: var(--font-mono); font-size: 11px; font-weight: 700; letter-spacing: 0.05em;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,6 +64,7 @@
           <div class="tkr-bracket-meta">12-TEAM FIELD<br>SEEDS 1–4 BYE</div>
         </div>
         <div class="bk-cols" id="tkr-bracket-cols"></div>
+        <div class="bk-odds hidden" id="tkr-bracket-odds"></div>
       </div>
     </div>
 

--- a/frontend/js/board.js
+++ b/frontend/js/board.js
@@ -268,7 +268,19 @@
           } else {
             cfpSub = 'HOSTS R1';
           }
+          if (pt.bid_pct != null) cfpSub += ' · ' + fmtPct(pt.bid_pct) + ' BID';
           break;
+        }
+      }
+      // Outside the projected field, the simulation still has an opinion.
+      if (cfpSeed === '—' && PLAYOFF_DATA.bubble) {
+        for (var j = 0; j < PLAYOFF_DATA.bubble.length; j++) {
+          var bt = PLAYOFF_DATA.bubble[j];
+          if (bt.team_id === e.team_id && bt.bid_pct != null) {
+            cfpSeed = fmtPct(bt.bid_pct);
+            cfpSub = 'BID ODDS · ON THE BUBBLE';
+            break;
+          }
         }
       }
     }
@@ -806,10 +818,67 @@
       '<div class="bk-champ-win"><span>TITLE-GAME WIN</span><span class="v">' + Math.round(ch.title_game_win_prob) + '%</span></div></div>';
   }
 
+  // Percentages read better without a trailing ".0" on whole numbers.
+  function fmtPct(v) {
+    if (v == null) return '—';
+    return (Math.round(v * 10) / 10).toFixed(v < 10 ? 1 : 0) + '%';
+  }
+
+  function oddsRow(t, inField) {
+    var c = stripeName(t.name);
+    return '<div class="bk-odds-row' + (inField ? '' : ' out') + '">' +
+      '<span class="bk-odds-seed">' + (inField ? t.seed : '—') + '</span>' +
+      '<span class="bk-stripe" style="background:' + c + '"></span>' +
+      '<span class="bk-odds-name">' + esc(abbrName(t.name)) + '</span>' +
+      '<span class="bk-odds-bar"><i style="width:' + Math.max(1, Math.round(t.bid_pct)) + '%;background:' + c + '"></i></span>' +
+      '<span class="bk-odds-pct">' + fmtPct(t.bid_pct) + '</span>' +
+      '<span class="bk-odds-sub">' + fmtPct(t.conf_title_pct) + '</span>' +
+      '<span class="bk-odds-sub">' + fmtPct(t.title_pct) + '</span></div>';
+  }
+
+  // Per-team probabilities only exist for a simulated season; the deterministic
+  // current-ratings fallback has nothing to put here.
+  function renderOdds(data) {
+    var host = document.getElementById('tkr-bracket-odds');
+    if (!host) return;
+    if (data.method !== 'monte_carlo' || !data.field.length || data.field[0].bid_pct == null) {
+      host.innerHTML = '';
+      host.classList.add('hidden');
+      return;
+    }
+    var head = '<div class="bk-odds-head"><span class="bk-odds-seed">SD</span>' +
+      '<span class="bk-stripe"></span><span class="bk-odds-name">TEAM</span>' +
+      '<span class="bk-odds-bar"></span><span class="bk-odds-pct">PLAYOFF</span>' +
+      '<span class="bk-odds-sub">CONF</span><span class="bk-odds-sub">TITLE</span></div>';
+    var rows = data.field.map(function (t) { return oddsRow(t, true); }).join('');
+    var bubble = (data.bubble || []).slice(0, 8);
+    if (bubble.length) {
+      rows += '<div class="bk-odds-split">ON THE BUBBLE</div>' +
+        bubble.map(function (t) { return oddsRow(t, false); }).join('');
+    }
+    host.innerHTML = '<h3 class="bk-odds-title">Playoff odds</h3>' + head + rows;
+    host.classList.remove('hidden');
+  }
+
+  function renderBracketHead(data) {
+    var sub = document.querySelector('.tkr-bracket-sub');
+    var meta = document.querySelector('.tkr-bracket-meta');
+    if (sub) {
+      sub.textContent = data.method === 'monte_carlo'
+        ? 'Consensus field from ' + Number(data.runs).toLocaleString() + ' simulated seasons · ▸ marks the favored side advancing.'
+        : 'Seeded from current ratings · ▸ marks the favored side advancing.';
+    }
+    if (meta) {
+      meta.innerHTML = '12-TEAM FIELD<br>SEEDS 1–4 BYE' +
+        (data.through_week != null ? '<br>THROUGH WK ' + data.through_week : '');
+    }
+  }
+
   function renderBracket(data) {
     var card = document.getElementById('tkr-bracket');
     if (!card) return;
     if (!data || !data.field || !data.field.length) { card.classList.add('hidden'); return; }
+    renderBracketHead(data);
     var cols = ROUNDS.map(function (r) {
       var items = r.key === 'final' ? (data.final ? [data.final] : []) : (data[r.key] || []);
       return '<div class="bk-col"><div class="bk-round"><div class="bk-round-t">' + r.t + '</div>' +
@@ -819,6 +888,7 @@
     cols += '<div class="bk-col champion"><div class="bk-round"><div class="bk-round-t">CHAMPION</div>' +
       '<div class="bk-round-d">PROJECTED</div></div><div class="bk-col-body">' + championCard(data.champion) + '</div></div>';
     document.getElementById('tkr-bracket-cols').innerHTML = cols;
+    renderOdds(data);
     card.classList.remove('hidden');
   }
 

--- a/migrations/migrate_add_playoff_simulation.py
+++ b/migrations/migrate_add_playoff_simulation.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Database Migration: Add the playoff_simulation cache table
+
+Creates the table that holds the cached Monte Carlo playoff projection:
+    - season      (INTEGER)  season the projection covers
+    - week        (INTEGER)  week the season had reached when it ran
+    - runs        (INTEGER)  number of simulated seasons behind the numbers
+    - payload     (TEXT)     the full projection, JSON encoded
+    - created_at  (DATETIME) when the simulation ran
+
+Ten thousand simulated seasons take several seconds, which is too slow for a web
+request and pointless to repeat — the answer only moves when new results land.
+The weekly import writes here; the API reads.
+
+Idempotent: uses CREATE TABLE IF NOT EXISTS. Safe to run multiple times.
+
+Rollback: DROP TABLE playoff_simulation. The projection endpoint falls back to
+the deterministic current-ratings bracket when no row is present, so dropping
+the table degrades the feature rather than breaking it.
+"""
+
+import sqlite3
+import sys
+
+DDL = """
+CREATE TABLE IF NOT EXISTS playoff_simulation (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    season      INTEGER  NOT NULL,
+    week        INTEGER  NOT NULL,
+    runs        INTEGER  NOT NULL,
+    payload     TEXT     NOT NULL,
+    created_at  DATETIME NOT NULL,
+    CONSTRAINT uq_playoff_sim_season_week UNIQUE (season, week)
+)
+"""
+
+INDEXES = [
+    "CREATE INDEX IF NOT EXISTS ix_playoff_simulation_season ON playoff_simulation (season)",
+    "CREATE INDEX IF NOT EXISTS ix_playoff_simulation_week ON playoff_simulation (week)",
+]
+
+
+def migrate(db_path: str = "cfb_rankings.db") -> int:
+    print("=" * 70)
+    print("MIGRATION: Add playoff_simulation table")
+    print("=" * 70)
+    try:
+        conn = sqlite3.connect(db_path)
+        cur = conn.cursor()
+        existed = cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='playoff_simulation'"
+        ).fetchone()
+        cur.execute(DDL)
+        for stmt in INDEXES:
+            cur.execute(stmt)
+        conn.commit()
+        conn.close()
+        if existed:
+            print("⚠️  Table 'playoff_simulation' already exists — skipping")
+        else:
+            print("✓ Created table playoff_simulation")
+        print("\n✓ Migration complete")
+        return 0
+    except sqlite3.OperationalError as e:
+        print(f"❌ Migration failed: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(migrate(sys.argv[1] if len(sys.argv) > 1 else "cfb_rankings.db"))

--- a/scripts/simulate_season.py
+++ b/scripts/simulate_season.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Simulate the rest of a season and cache the playoff projection.
+
+Run on demand; the weekly import calls the same code path automatically.
+
+    python3 scripts/simulate_season.py                    # active season, 10k runs
+    python3 scripts/simulate_season.py --season 2026
+    python3 scripts/simulate_season.py --runs 2000 --seed 7 --dry-run
+"""
+
+import argparse
+import os
+import sys
+
+# Add parent directory to path so we can import modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import time
+
+from src.core.season_simulation import DEFAULT_RUNS, build_projection, refresh_projection
+from src.models.database import SessionLocal
+from src.models.models import Season
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--season", type=int, help="Season year (defaults to the active season)")
+    p.add_argument("--runs", type=int, default=DEFAULT_RUNS, help=f"Simulated seasons (default {DEFAULT_RUNS})")
+    p.add_argument("--seed", type=int, help="Random seed, for a reproducible run")
+    p.add_argument("--dry-run", action="store_true", help="Print the projection without caching it")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    db = SessionLocal()
+    try:
+        season = args.season
+        if not season:
+            active = db.query(Season).filter(Season.is_active == True).first()  # noqa: E712
+            if not active:
+                print("❌ No active season found. Pass --season explicitly.")
+                return 1
+            season = active.year
+
+        print(f"Simulating {season} — {args.runs:,} seasons...")
+        started = time.time()
+        if args.dry_run:
+            projection = build_projection(db, season, runs=args.runs, seed=args.seed)
+        else:
+            projection = refresh_projection(db, season, runs=args.runs, seed=args.seed)
+        elapsed = time.time() - started
+
+        if not projection["field"]:
+            print(f"⚠️  Not enough teams to build a field for {season}")
+            return 1
+
+        print(f"✓ Done in {elapsed:.1f}s (through week {projection['through_week']})\n")
+        header = f'{"SEED":>4}  {"TEAM":<22} {"CONFERENCE":<18} {"RATING":>8} {"BID%":>6} {"CONF%":>6} {"NAT%":>6} {"PROJ W":>7}'
+        print(header)
+        print("-" * len(header))
+        for t in projection["field"]:
+            print(
+                f'{t["seed"]:>4}  {t["name"]:<22} {str(t["conference_name"]):<18} '
+                f'{t["elo"]:8.1f} {t["bid_pct"]:6.1f} {t["conf_title_pct"]:6.1f} '
+                f'{t["title_pct"]:6.1f} {t["proj_wins"]:7.1f}'
+            )
+
+        if projection["bubble"]:
+            print("\nBubble:")
+            for b in projection["bubble"][:8]:
+                print(f'      {b["name"]:<22} {str(b["conference_name"]):<18} {b["elo"]:8.1f} {b["bid_pct"]:6.1f}')
+
+        print(f'\nProjected champion: {projection["champion"]["name"]}')
+        if args.dry_run:
+            print("(dry run — nothing was written)")
+        return 0
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/api/routers/rankings.py
+++ b/src/api/routers/rankings.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from src.core.ranking_service import RankingService, project_playoff_bracket
+from src.core.season_simulation import load_cached_projection, refresh_projection
 from src.models import schemas
 from src.models.database import get_db
 from src.models.models import Game, RankingHistory, Season, Team
@@ -288,15 +289,43 @@ async def get_postseason(season: int, db: Session = Depends(get_db)):
 
 
 @router.get("/api/playoff-projection", tags=["Rankings"])
-async def get_playoff_projection(season: Optional[int] = None, db: Session = Depends(get_db)):
-    """Project the 12-team CFP bracket from current Elo (EPIC-044 Story 44.11).
+async def get_playoff_projection(
+    season: Optional[int] = None,
+    refresh: bool = False,
+    db: Session = Depends(get_db),
+):
+    """Project the 12-team CFP bracket (EPIC-044 Story 44.11).
 
-    CFP-style field selection (conference-champion auto-bids + at-large), straight
-    seeding by Elo, each round simulated with the standard prediction formula.
+    Serves the cached Monte Carlo projection: the remaining schedule played out
+    thousands of times, with ratings evolving game by game and a synthesized
+    conference championship in every eligible league. Each team carries its
+    playoff-bid, conference-title and national-title probability, and the
+    rendered bracket is the consensus field.
+
+    Falls back to the deterministic current-ratings bracket when no simulation
+    has been cached yet, distinguishable by ``method``: ``"monte_carlo"`` versus
+    ``"current_ratings"``.
+
+    Args:
+        season: Season year (defaults to the active season)
+        refresh: Re-run the simulation now instead of reading the cache. Takes
+            several seconds; intended for admin and debugging, not page loads.
+        db: Database session (injected by FastAPI)
+
+    Example:
+        GET /api/playoff-projection?season=2026
     """
     if not season:
         active = db.query(Season).filter(Season.is_active == True).first()
         season = active.year if active else datetime.now().year
+
+    if refresh:
+        return refresh_projection(db, season)
+
+    cached = load_cached_projection(db, season)
+    if cached:
+        return cached
+
     return project_playoff_bracket(db, season)
 
 

--- a/src/core/position_weights.json
+++ b/src/core/position_weights.json
@@ -16,9 +16,9 @@
     "ST": 0.0
   },
   "max_bonus": 150,
-  "previous_season_weight": 0.35,
-  "mean_regression_factor": 0.60,
-  "returning_regression_scale": 0.60,
+  "previous_season_weight": 0.60,
+  "mean_regression_factor": 0.75,
+  "returning_regression_scale": 0.45,
   "top_players_per_position": {
     "QB": 3,
     "OL": 5,
@@ -37,9 +37,9 @@
     "blend_weight": "EPIC-040: w_prod in [0,1] — production share of the blend (recruiting gets 1 - w_prod). Used by import_production.py when computing blended_rating.",
     "weights": "Position group weights (must sum to 1.0) - reflects relative importance of each position to team success",
     "max_bonus": "Maximum bonus points contribution to preseason rating (base 1500 + other bonuses + this)",
-    "previous_season_weight": "EPIC-030: How much previous season ELO blends into preseason (0=disabled, 0.35=recommended). Start at 0.0 until validated.",
-    "mean_regression_factor": "EPIC-030: Base regression toward 1500 before blending (0=full reset, 1=no regression). Default 0.60.",
-    "returning_regression_scale": "EPIC-030: How much returning_production modulates regression. Formula: clamp(base + (ret_prod - 0.5) * scale, 0.30, 0.85). Default 0.60.",
+    "previous_season_weight": "EPIC-030: How much previous season ELO blends into preseason (0=disabled). Raised 0.35->0.60 on 2026-08-23: a chained 2021-2025 replay (3080 games) put the optimal total shrink on last season near 0.75, versus the 0.21 that 0.35*0.60 produced.",
+    "mean_regression_factor": "EPIC-030: Base regression toward 1500 before blending (0=full reset, 1=no regression). 0.75 fitted on a 2021-2025 game-level log-loss sweep.",
+    "returning_regression_scale": "EPIC-030: How much returning_production modulates regression. Formula: clamp(base + (ret_prod - 0.5) * scale, 0.30, 0.95). 0.45 fitted on 528 team-seasons; effect is real but small (t=+1.70).",
     "top_players_per_position": "Number of top recruits to consider when calculating position group strength",
     "rationale": {
       "QB_30_percent": "Quarterback is most valuable position in college football",

--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -409,7 +409,7 @@ class RankingService:
 
                     if returning_prod is not None:
                         dynamic_regression = base_regression + (returning_prod - 0.5) * returning_scale
-                        regression = max(0.30, min(0.85, dynamic_regression))
+                        regression = max(0.30, min(0.95, dynamic_regression))
                     else:
                         regression = base_regression
 

--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -1406,12 +1406,29 @@ _QF_BOWLS = ["Rose Bowl", "Sugar Bowl", "Fiesta Bowl", "Peach Bowl"]
 _SF_BOWLS = ["Cotton Bowl", "Orange Bowl"]
 _INDEPENDENT_CONFS = {None, "", "Independent", "Independents", "FBS Independents"}
 
+# CFP format knobs. The 2025-26 format is a 12-team field with five conference
+# champions auto-bid and straight 1-12 seeding by rating. The format is under
+# active revision, so keep these as constants rather than magic numbers.
+FIELD_SIZE = 12
+POWER_AUTO_BIDS = 4
+G5_AUTO_BIDS = 1
 
-def _project_matchup(high: dict, low: dict, neutral: bool, label: str) -> dict:
+# A conference too small to be a real league does not get a projected champion.
+# ponytail: guards against stale realignment data (the teams table currently
+# lists a 2-team Pac-12); self-corrects once the team importer refreshes.
+MIN_CONFERENCE_SIZE = 4
+
+
+def _project_matchup(high: dict, low: dict, neutral: bool, label: str, rng=None) -> dict:
     """Simulate one playoff game. `high` is the higher seed (hosts unless neutral).
 
     Mirrors _calculate_game_prediction exactly: +65 home-field unless neutral,
     400-scale logistic win prob, scores = 30 ± (rating_diff / 100) * 3.5.
+
+    Args:
+        rng: When given, the winner is *sampled* from the win probability instead
+            of chalked to the favorite. The Monte Carlo season simulation passes
+            one; the deterministic projection leaves it None.
     """
     home_elo = high["elo"] + (0 if neutral else 65)
     away_elo = low["elo"]
@@ -1423,7 +1440,8 @@ def _project_matchup(high: dict, low: dict, neutral: bool, label: str) -> dict:
                  "elo": high["elo"], "score": hs, "win_prob": round(home_wp * 100, 1)}
     low_side = {"seed": low["seed"], "team_id": low["team_id"], "name": low["name"],
                 "elo": low["elo"], "score": ls, "win_prob": round((1 - home_wp) * 100, 1)}
-    winner = high_side if home_wp >= 0.5 else low_side
+    high_wins = (rng.random() < home_wp) if rng is not None else (home_wp >= 0.5)
+    winner = high_side if high_wins else low_side
     return {"label": label, "neutral": neutral, "high": high_side, "low": low_side,
             "winner_id": winner["team_id"], "winner_seed": winner["seed"]}
 
@@ -1432,103 +1450,149 @@ def _winner_of(m: dict) -> dict:
     return m["high"] if m["winner_id"] == m["high"]["team_id"] else m["low"]
 
 
-def _sim(a: dict, b: dict, neutral: bool, label: str) -> dict:
+def _sim(a: dict, b: dict, neutral: bool, label: str, rng=None) -> dict:
     high, low = (a, b) if a["seed"] < b["seed"] else (b, a)
-    return _project_matchup(high, low, neutral, label)
+    return _project_matchup(high, low, neutral, label, rng)
 
 
-def project_playoff_bracket(db: Session, season: int) -> dict:
-    """Project the 12-team CFP bracket from current Elo (EPIC-044 Story 44.11).
+def conference_sizes(db: Session) -> Dict[str, int]:
+    """FBS member count per conference name, used for champion eligibility."""
+    sizes: Dict[str, int] = {}
+    for name, in db.query(Team.conference_name).filter(Team.is_fcs == False).all():  # noqa: E712
+        if name in _INDEPENDENT_CONFS:
+            continue
+        sizes[name] = sizes.get(name, 0) + 1
+    return sizes
 
-    Field selection (CFP-style): each conference's highest-Elo team is its
-    projected champion; the 4 highest-Elo power (P5) champions plus the single
-    highest-Elo Group-of-5 champion get auto-bids; the field is filled to 12 with
-    the highest-Elo remaining teams as at-large. All 12 are then seeded strictly
-    by Elo (straight seeding); seeds 1–4 get first-round byes.
+
+def top_rated_champions(rankings: List[dict], conf_sizes: Dict[str, int]) -> List[dict]:
+    """Projected conference champions = highest-rated team in each eligible league.
+
+    The cheap stand-in used when no season has been simulated. Conferences below
+    MIN_CONFERENCE_SIZE are skipped so stale realignment data cannot mint a
+    champion (and therefore an auto-bid) out of a two-team conference.
     """
-    svc = RankingService(db)
-    rankings = svc.get_current_rankings(season, limit=60)
-    if len(rankings) < 12:
-        return {"season": season, "field": [], "first_round": [], "quarterfinals": [],
-                "semifinals": [], "final": None, "champion": None}
-
-    by_id = {r["team_id"]: r for r in rankings}
-
-    # Projected conference champions = top-Elo team per conference (excl. independents/FCS).
-    champ_by_conf: dict = {}
+    champ_by_conf: Dict[str, dict] = {}
     for r in rankings:
         conf = r.get("conference_name")
         if conf in _INDEPENDENT_CONFS or r.get("conference") == "FCS":
             continue
+        if conf_sizes.get(conf, 0) < MIN_CONFERENCE_SIZE:
+            continue
         cur = champ_by_conf.get(conf)
         if cur is None or r["elo_rating"] > cur["elo_rating"]:
             champ_by_conf[conf] = r
-    champs = list(champ_by_conf.values())
-    power_champs = sorted([c for c in champs if c.get("conference") in ("P5", "P4")],
-                          key=lambda c: c["elo_rating"], reverse=True)
-    g5_champs = sorted([c for c in champs if c.get("conference") == "G5"],
-                       key=lambda c: c["elo_rating"], reverse=True)
+    return list(champ_by_conf.values())
 
-    auto = power_champs[:4] + g5_champs[:1]
-    if len(auto) < 5:  # backfill if a tier is short
-        for c in sorted(champs, key=lambda c: c["elo_rating"], reverse=True):
-            if c not in auto:
-                auto.append(c)
-            if len(auto) >= 5:
+
+def select_cfp_field(rankings: List[dict], champs: List[dict]) -> List[dict]:
+    """Seed the CFP field from a rating-ordered team list and a champion list.
+
+    The single place the CFP selection rule lives, so the deterministic
+    projection and the Monte Carlo simulation cannot drift apart. Both callers
+    pass dicts carrying team_id / team_name / elo_rating / conference /
+    conference_name; `rankings` must already be sorted by rating descending.
+
+    POWER_AUTO_BIDS highest-rated P5 champions plus G5_AUTO_BIDS highest-rated
+    G5 champion take auto-bids, the field fills to FIELD_SIZE with the best
+    remaining teams, and all of them are seeded straight by rating.
+    """
+    auto_total = POWER_AUTO_BIDS + G5_AUTO_BIDS
+    by_rating = lambda c: c["elo_rating"]  # noqa: E731
+    power_champs = sorted([c for c in champs if c.get("conference") == "P5"],
+                          key=by_rating, reverse=True)
+    g5_champs = sorted([c for c in champs if c.get("conference") == "G5"],
+                       key=by_rating, reverse=True)
+
+    auto = power_champs[:POWER_AUTO_BIDS] + g5_champs[:G5_AUTO_BIDS]
+    if len(auto) < auto_total:  # backfill if a tier is short
+        auto_so_far = {c["team_id"] for c in auto}
+        for c in sorted(champs, key=by_rating, reverse=True):
+            if len(auto) >= auto_total:
                 break
+            if c["team_id"] not in auto_so_far:
+                auto.append(c)
+                auto_so_far.add(c["team_id"])
     auto_ids = {c["team_id"] for c in auto}
 
     field = list(auto)
-    for r in rankings:  # at-large by Elo
-        if len(field) >= 12:
+    for r in rankings:  # at-large by rating
+        if len(field) >= FIELD_SIZE:
             break
         if r["team_id"] not in auto_ids:
             field.append(r)
 
-    field.sort(key=lambda r: r["elo_rating"], reverse=True)
+    field.sort(key=by_rating, reverse=True)
     champ_ids = {c["team_id"] for c in champs}
-    seeded = []
-    for i, r in enumerate(field[:12]):
-        seeded.append({
-            "seed": i + 1, "team_id": r["team_id"], "name": r["team_name"],
-            "elo": r["elo_rating"], "conference_name": r.get("conference_name"),
-            "is_champ": r["team_id"] in champ_ids, "auto_bid": r["team_id"] in auto_ids,
-        })
-    s = {t["seed"]: t for t in seeded}  # seed → team
-
-    # First round (seeds 5–12 host higher seed, on campus → not neutral).
-    fr = [
-        _sim(s[8], s[9], False, s[8]["name"]),
-        _sim(s[5], s[12], False, s[5]["name"]),
-        _sim(s[7], s[10], False, s[7]["name"]),
-        _sim(s[6], s[11], False, s[6]["name"]),
+    return [
+        {"seed": i + 1, "team_id": r["team_id"], "name": r["team_name"],
+         "elo": r["elo_rating"], "conference_name": r.get("conference_name"),
+         "is_champ": r["team_id"] in champ_ids, "auto_bid": r["team_id"] in auto_ids}
+        for i, r in enumerate(field[:FIELD_SIZE])
     ]
-    # Quarterfinals (neutral): byes enter vs first-round winners.
+
+
+def run_bracket(seeded: List[dict], rng=None) -> dict:
+    """Play the 12-team bracket out from a seeded field.
+
+    Seeds 5-12 meet on the higher seed's campus; every later round is neutral.
+    Pass an `rng` to sample each game instead of advancing the favorite.
+    """
+    s = {t["seed"]: t for t in seeded}  # seed → team
+    fr = [
+        _sim(s[8], s[9], False, s[8]["name"], rng),
+        _sim(s[5], s[12], False, s[5]["name"], rng),
+        _sim(s[7], s[10], False, s[7]["name"], rng),
+        _sim(s[6], s[11], False, s[6]["name"], rng),
+    ]
     qf = [
-        _sim(s[1], _winner_of(fr[0]), True, _QF_BOWLS[0]),
-        _sim(s[4], _winner_of(fr[1]), True, _QF_BOWLS[1]),
-        _sim(s[2], _winner_of(fr[2]), True, _QF_BOWLS[2]),
-        _sim(s[3], _winner_of(fr[3]), True, _QF_BOWLS[3]),
+        _sim(s[1], _winner_of(fr[0]), True, _QF_BOWLS[0], rng),
+        _sim(s[4], _winner_of(fr[1]), True, _QF_BOWLS[1], rng),
+        _sim(s[2], _winner_of(fr[2]), True, _QF_BOWLS[2], rng),
+        _sim(s[3], _winner_of(fr[3]), True, _QF_BOWLS[3], rng),
     ]
     sf = [
-        _sim(_winner_of(qf[0]), _winner_of(qf[1]), True, _SF_BOWLS[0]),
-        _sim(_winner_of(qf[2]), _winner_of(qf[3]), True, _SF_BOWLS[1]),
+        _sim(_winner_of(qf[0]), _winner_of(qf[1]), True, _SF_BOWLS[0], rng),
+        _sim(_winner_of(qf[2]), _winner_of(qf[3]), True, _SF_BOWLS[1], rng),
     ]
-    final = _sim(_winner_of(sf[0]), _winner_of(sf[1]), True, "CFP Championship")
+    final = _sim(_winner_of(sf[0]), _winner_of(sf[1]), True, "CFP Championship", rng)
     champ = _winner_of(final)
-
     return {
-        "season": season,
-        "field": seeded,
-        "first_round": fr,
-        "quarterfinals": qf,
-        "semifinals": sf,
-        "final": final,
+        "first_round": fr, "quarterfinals": qf, "semifinals": sf, "final": final,
         "champion": {
             "seed": champ["seed"], "team_id": champ["team_id"], "name": champ["name"],
             "conference_name": s[champ["seed"]]["conference_name"],
             "title_game_win_prob": champ["win_prob"],
         },
+    }
+
+
+def project_playoff_bracket(db: Session, season: int) -> dict:
+    """Project the 12-team CFP bracket from current ratings (EPIC-044 Story 44.11).
+
+    The cheap, deterministic projection: each conference's highest-rated team is
+    treated as its champion, the field is selected and straight-seeded by
+    :func:`select_cfp_field`, and every round chalks to the favorite.
+
+    This is the fallback shown before a season has been simulated. The richer
+    view — playoff odds from a simulated season — lives in
+    :mod:`src.core.season_simulation`.
+    """
+    svc = RankingService(db)
+    rankings = svc.get_current_rankings(season, limit=60)
+    if len(rankings) < FIELD_SIZE:
+        return {"season": season, "field": [], "first_round": [], "quarterfinals": [],
+                "semifinals": [], "final": None, "champion": None,
+                "method": "current_ratings"}
+
+    champs = top_rated_champions(rankings, conference_sizes(db))
+    seeded = select_cfp_field(rankings, champs)
+
+    return {
+        "season": season,
+        "field": seeded,
+        "method": "current_ratings",
+        **run_bracket(seeded),
     }
 
 

--- a/src/core/season_simulation.py
+++ b/src/core/season_simulation.py
@@ -1,0 +1,513 @@
+"""Monte Carlo simulation of the remaining season, used to seed the CFP bracket.
+
+The projected playoff bracket used to be seeded from *today's* ratings: the
+highest-rated team in each conference was called its champion, and the field was
+the top 12 by rating. In Week 1 that is a preseason-ratings bracket wearing a
+playoff costume — it knows nothing about who still has to play whom.
+
+This module plays the rest of the schedule out thousands of times instead. Each
+run samples every remaining game from the same logistic win probability the
+prediction endpoint uses, feeds the result back through the ELO update so
+ratings drift across the simulated season, synthesizes a conference
+championship game for every eligible league, and selects a CFP field. Counting
+across runs turns that into playoff bid odds, conference title odds and an
+average seed per team.
+
+Why the loop is written on plain lists rather than the ORM:
+
+    ``RankingService.process_game`` mutates Team rows, marks the game processed
+    and commits. It also refuses any game flagged ``excluded_from_rankings``,
+    which every unplayed future game is. None of that is usable here, so the ELO
+    arithmetic is mirrored on in-memory arrays. The shared constants and helpers
+    (:func:`RankingService.get_k_factor`, ``calculate_mov_multiplier``,
+    ``get_conference_multiplier``) are imported rather than re-derived, so the
+    simulated update tracks the real one.
+
+Simplifications, all deliberate:
+
+    * Games against FCS opponents are skipped entirely. That matches production,
+      where FCS games are excluded from rankings and therefore never touch ELO
+      or the displayed win/loss record.
+    * Conference championship participants are the top two by conference record.
+      The Team model carries no division field, and post-2023 realignment most
+      conferences seed their title game exactly this way.
+    * Game outcomes are independent. No injuries, weather, or rivalry effects.
+"""
+
+import json
+import logging
+import math
+import random
+from dataclasses import dataclass, field as dc_field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from src.core.ranking_service import (
+    FIELD_SIZE,
+    MIN_CONFERENCE_SIZE,
+    RankingService,
+    _INDEPENDENT_CONFS,
+    blend_rating,
+    conference_sizes,
+    efficiency_rating,
+    efficiency_scale,
+    run_bracket,
+    select_cfp_field,
+)
+from src.models.models import ConferenceType, Game, PlayoffSimulation, Season, Team
+
+logger = logging.getLogger(__name__)
+
+# Points of final margin implied by one ELO point. Mirrors the prediction
+# formula in _calculate_game_prediction: (rating_diff / 100) * 3.5 per team,
+# so 7 points of margin per 100 ELO.
+MARGIN_PER_ELO = 0.07
+
+# Spread of actual results around that expectation. ~16 points is the residual
+# scale of college football finals against a rating-implied line.
+# ponytail: a single global sigma, not a per-team or pace-aware one. Revisit if
+# the simulated ELO spread drifts away from the real end-of-season spread.
+MARGIN_SIGMA = 16.0
+
+# Conference championship games are played the week after the regular season.
+CHAMPIONSHIP_WEEK = 14
+
+DEFAULT_RUNS = 10_000
+
+
+@dataclass
+class SimInputs:
+    """Everything the simulation loop needs, flattened to index-addressed lists.
+
+    Teams are addressed by a dense index (0..n-1), not by database id, so the
+    inner loop works on plain list lookups.
+    """
+
+    season: int
+    through_week: int
+    team_ids: List[int]
+    names: List[str]
+    tiers: List[str]  # "P5" / "G5"
+    conf_names: List[Optional[str]]
+    base_elo: List[float]  # pure ELO, as stored on teams.elo_rating
+    eff: List[Optional[float]]  # efficiency rating on the ELO scale, or None
+    wins: List[int]  # already banked this season
+    losses: List[int]
+    conf_wins: List[int]
+    conf_losses: List[int]
+    games: List[Tuple[int, int, int, bool, bool]]  # home, away, week, neutral, is_conference
+    conf_members: Dict[str, List[int]] = dc_field(default_factory=dict)
+
+    @property
+    def n_teams(self) -> int:
+        return len(self.team_ids)
+
+
+def load_sim_inputs(db: Session, season: int) -> SimInputs:
+    """Read the FBS teams, their banked records and the unplayed schedule.
+
+    The only database work the simulation does. Everything after this is pure
+    arithmetic on lists.
+    """
+    teams = db.query(Team).filter(Team.is_fcs == False).all()  # noqa: E712
+    teams.sort(key=lambda t: t.id)
+    idx = {t.id: i for i, t in enumerate(teams)}
+
+    scale = efficiency_scale(db)
+    eff = [
+        efficiency_rating(t, scale) if scale is not None else None
+        for t in teams
+    ]
+
+    season_obj = db.query(Season).filter(Season.year == season).first()
+    through_week = season_obj.current_week if season_obj else 0
+
+    conf_members: Dict[str, List[int]] = {}
+    for i, t in enumerate(teams):
+        if t.conference_name in _INDEPENDENT_CONFS:
+            continue
+        conf_members.setdefault(t.conference_name, []).append(i)
+
+    sizes = conference_sizes(db)
+    conf_members = {
+        name: members
+        for name, members in conf_members.items()
+        if sizes.get(name, 0) >= MIN_CONFERENCE_SIZE and len(members) >= 2
+    }
+
+    n = len(teams)
+    wins, losses = [0] * n, [0] * n
+    conf_wins, conf_losses = [0] * n, [0] * n
+    games: List[Tuple[int, int, int, bool, bool]] = []
+
+    for g in db.query(Game).filter(Game.season == season).order_by(Game.week).all():
+        h, a = idx.get(g.home_team_id), idx.get(g.away_team_id)
+        if h is None or a is None:
+            continue  # FCS opponent: never affects ELO or the displayed record
+        same_conf = (
+            teams[h].conference_name == teams[a].conference_name
+            and teams[h].conference_name not in _INDEPENDENT_CONFS
+        )
+        if g.is_processed:
+            hi, lo = (h, a) if g.home_score > g.away_score else (a, h)
+            wins[hi] += 1
+            losses[lo] += 1
+            if same_conf:
+                conf_wins[hi] += 1
+                conf_losses[lo] += 1
+        else:
+            games.append((h, a, g.week, bool(g.is_neutral_site), same_conf))
+
+    return SimInputs(
+        season=season,
+        through_week=through_week,
+        team_ids=[t.id for t in teams],
+        names=[t.name for t in teams],
+        tiers=[
+            "G5" if t.conference == ConferenceType.GROUP_5 else "P5" for t in teams
+        ],
+        conf_names=[t.conference_name for t in teams],
+        base_elo=[t.elo_rating for t in teams],
+        eff=eff,
+        wins=wins,
+        losses=losses,
+        conf_wins=conf_wins,
+        conf_losses=conf_losses,
+        games=games,
+        conf_members=conf_members,
+    )
+
+
+def _k_factor(week: int) -> float:
+    """Progressive K-factor, straight from RankingService (64 → 48 → 32)."""
+    if week <= 4:
+        return RankingService.K_FACTOR_EARLY
+    if week <= 8:
+        return RankingService.K_FACTOR_MID
+    return RankingService.K_FACTOR_LATE
+
+
+def _conf_multipliers(winner_tier: str, loser_tier: str) -> Tuple[float, float]:
+    """Cross-tier ELO multipliers. Mirrors RankingService.get_conference_multiplier.
+
+    FCS branches are omitted because FCS games never reach the simulation.
+    """
+    if winner_tier == "P5" and loser_tier == "G5":
+        return (0.9, 1.1)
+    if winner_tier == "G5" and loser_tier == "P5":
+        return (1.1, 0.9)
+    return (1.0, 1.0)
+
+
+def _play(sim, h: int, a: int, week: int, neutral: bool, is_conf: bool, rng) -> int:
+    """Sample one game, apply the ELO update in place, return the winner's index.
+
+    `sim` is the mutable per-run state produced by :func:`_new_run_state`.
+    """
+    elo = sim["elo"]
+    home_rating = elo[h] + (0 if neutral else RankingService.HOME_FIELD_ADVANTAGE)
+    away_rating = elo[a]
+    home_wp = 1.0 / (1.0 + 10 ** ((away_rating - home_rating) / RankingService.RATING_SCALE))
+
+    home_won = rng.random() < home_wp
+    winner, loser = (h, a) if home_won else (a, h)
+    winner_expected = home_wp if home_won else 1.0 - home_wp
+
+    # Margin is sampled conditional on who actually won: when the favorite wins
+    # it is centered on the rating-implied margin, when the underdog wins it is
+    # centered on zero. Upsets therefore tend to be close games, which is both
+    # true and what keeps the MOV multiplier from rewarding flukes.
+    edge = abs(home_rating - away_rating) * MARGIN_PER_ELO
+    favorite_won = home_won == (home_rating >= away_rating)
+    margin = abs(rng.gauss(edge if favorite_won else 0.0, MARGIN_SIGMA))
+    mov = min(math.log(max(margin, 1.0) + 1.0), RankingService.MAX_MOV_MULTIPLIER)
+
+    k = _k_factor(week)
+    winner_mult, loser_mult = _conf_multipliers(sim["tiers"][winner], sim["tiers"][loser])
+    elo[winner] += k * (1.0 - winner_expected) * mov * winner_mult
+    elo[loser] += k * (0.0 - (1.0 - winner_expected)) * mov * loser_mult
+
+    sim["wins"][winner] += 1
+    sim["losses"][loser] += 1
+    if is_conf:
+        sim["conf_wins"][winner] += 1
+        sim["conf_losses"][loser] += 1
+    return winner
+
+
+def _new_run_state(inputs: SimInputs) -> dict:
+    return {
+        "elo": list(inputs.base_elo),
+        "wins": list(inputs.wins),
+        "losses": list(inputs.losses),
+        "conf_wins": list(inputs.conf_wins),
+        "conf_losses": list(inputs.conf_losses),
+        "tiers": inputs.tiers,
+    }
+
+
+def _conference_champions(inputs: SimInputs, sim: dict, rng) -> List[int]:
+    """Synthesize a title game per eligible conference; return winners' indices.
+
+    The two participants are the best two by conference winning percentage,
+    rating as the tiebreak. The 2026 schedule contains no championship games at
+    all — CFBD only publishes them in weeks 14-15, once the matchups are known.
+    """
+    champions = []
+    for members in inputs.conf_members.values():
+        ranked = sorted(
+            members,
+            key=lambda i: (
+                sim["conf_wins"][i] / max(sim["conf_wins"][i] + sim["conf_losses"][i], 1),
+                sim["elo"][i],
+            ),
+            reverse=True,
+        )
+        one, two = ranked[0], ranked[1]
+        champions.append(_play(sim, one, two, CHAMPIONSHIP_WEEK, True, True, rng))
+    return champions
+
+
+def _final_ratings(inputs: SimInputs, sim: dict) -> List[float]:
+    """Blend each team's simulated ELO with its (fixed) efficiency rating.
+
+    Efficiency is held at its current value: adjusted PPA cannot be re-measured
+    for games that never happened. `week=None` skips the early-season gate,
+    since a simulated season is by definition complete.
+    """
+    elo = sim["elo"]
+    return [blend_rating(elo[i], inputs.eff[i], week=None) for i in range(inputs.n_teams)]
+
+
+def simulate_season(
+    inputs: SimInputs, runs: int = DEFAULT_RUNS, seed: Optional[int] = None
+) -> dict:
+    """Run the season `runs` times and aggregate per-team outcomes.
+
+    Returns a dict keyed by team index with bid counts, seed sums, conference
+    title counts, national title counts and summed final ratings — raw counters,
+    converted to percentages by :func:`build_projection`.
+    """
+    rng = random.Random(seed)
+    n = inputs.n_teams
+
+    bid_count = [0] * n
+    seed_sum = [0] * n
+    conf_title_count = [0] * n
+    title_count = [0] * n
+    rating_sum = [0.0] * n
+    win_sum = [0] * n
+
+    by_index = {}
+    team_dicts = [
+        {
+            "team_id": inputs.team_ids[i],
+            "team_name": inputs.names[i],
+            "conference": inputs.tiers[i],
+            "conference_name": inputs.conf_names[i],
+            "elo_rating": 0.0,
+            "_i": i,
+        }
+        for i in range(n)
+    ]
+    for d in team_dicts:
+        by_index[d["team_id"]] = d["_i"]
+
+    for _ in range(runs):
+        sim = _new_run_state(inputs)
+        for h, a, week, neutral, is_conf in inputs.games:
+            _play(sim, h, a, week, neutral, is_conf, rng)
+
+        champion_idx = _conference_champions(inputs, sim, rng)
+        finals = _final_ratings(inputs, sim)
+
+        for d in team_dicts:
+            d["elo_rating"] = finals[d["_i"]]
+        ranked = sorted(team_dicts, key=lambda d: d["elo_rating"], reverse=True)
+        champs = [team_dicts[i] for i in champion_idx]
+
+        seeded = select_cfp_field(ranked, champs)
+        bracket = run_bracket(seeded, rng)
+
+        for i in champion_idx:
+            conf_title_count[i] += 1
+        for t in seeded:
+            i = by_index[t["team_id"]]
+            bid_count[i] += 1
+            seed_sum[i] += t["seed"]
+        title_count[by_index[bracket["champion"]["team_id"]]] += 1
+
+        for i in range(n):
+            rating_sum[i] += finals[i]
+            win_sum[i] += sim["wins"][i]
+
+    return {
+        "runs": runs,
+        "bid_count": bid_count,
+        "seed_sum": seed_sum,
+        "conf_title_count": conf_title_count,
+        "title_count": title_count,
+        "rating_sum": rating_sum,
+        "win_sum": win_sum,
+    }
+
+
+# Teams outside the projected field that are still worth showing as "on the bubble".
+BUBBLE_SIZE = 13
+
+
+def build_projection(
+    db: Session, season: int, runs: int = DEFAULT_RUNS, seed: Optional[int] = None
+) -> dict:
+    """Simulate the season and return a playoff projection payload.
+
+    The bracket rendered is the *consensus* field, not a single simulated one:
+    the twelve teams with the highest playoff-bid probability, ordered by their
+    average seed, advanced on their mean final rating. A literal modal bracket is
+    not usable — across ten thousand runs no exact twelve-team field recurs often
+    enough to be meaningful. The consensus field is stable across reruns and is
+    what every published playoff projection shows.
+
+    The payload is a superset of :func:`project_playoff_bracket`'s, so the board
+    renders it unchanged and can layer the probabilities on top.
+    """
+    inputs = load_sim_inputs(db, season)
+    if inputs.n_teams < FIELD_SIZE:
+        return {
+            "season": season, "field": [], "first_round": [], "quarterfinals": [],
+            "semifinals": [], "final": None, "champion": None, "bubble": [],
+            "runs": 0, "method": "monte_carlo", "through_week": inputs.through_week,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    agg = simulate_season(inputs, runs=runs, seed=seed)
+    r = float(agg["runs"])
+
+    stats = []
+    for i in range(inputs.n_teams):
+        bids = agg["bid_count"][i]
+        stats.append({
+            "team_id": inputs.team_ids[i],
+            "team_name": inputs.names[i],
+            "conference": inputs.tiers[i],
+            "conference_name": inputs.conf_names[i],
+            # Mean final blended rating: what the bracket is advanced on.
+            "elo_rating": round(agg["rating_sum"][i] / r, 2),
+            "bid_pct": round(100.0 * bids / r, 1),
+            "avg_seed": round(agg["seed_sum"][i] / bids, 1) if bids else None,
+            "conf_title_pct": round(100.0 * agg["conf_title_count"][i] / r, 1),
+            "title_pct": round(100.0 * agg["title_count"][i] / r, 1),
+            "proj_wins": round(agg["win_sum"][i] / r, 1),
+            "_i": i,
+        })
+
+    # Each conference's most frequent champion stands as its projected champion.
+    by_team_id = {st["team_id"]: st for st in stats}
+    champions = [
+        by_team_id[inputs.team_ids[max(members, key=lambda i: agg["conf_title_count"][i])]]
+        for members in inputs.conf_members.values()
+    ]
+
+    # Consensus field. Selecting the plain top twelve by bid probability would
+    # produce an illegal bracket: bid probability is a marginal, so the five
+    # auto-bids every individual run honours do not survive the averaging. So the
+    # field goes through the same selection rule the runs use, with bid
+    # probability standing in as the ordering signal — that keeps the displayed
+    # bracket a field the CFP could actually produce.
+    for st in stats:
+        st["elo_rating"], st["mean_rating"] = st["bid_pct"], st["elo_rating"]
+    ranked_by_bid = sorted(stats, key=lambda st: -st["bid_pct"])
+    selected = select_cfp_field(ranked_by_bid, champions)
+    for st in stats:
+        st["elo_rating"] = st.pop("mean_rating")
+
+    # Seeds come from the average seed each team actually drew, and the bracket
+    # is advanced on mean final rating rather than on bid probability.
+    stat_by_id = {st["team_id"]: st for st in stats}
+    selected.sort(key=lambda t: stat_by_id[t["team_id"]]["avg_seed"] or FIELD_SIZE + 1)
+
+    seeded = []
+    for pos, t in enumerate(selected):
+        st = stat_by_id[t["team_id"]]
+        seeded.append({
+            "seed": pos + 1,
+            "team_id": st["team_id"],
+            "name": st["team_name"],
+            "elo": st["elo_rating"],
+            "conference_name": st["conference_name"],
+            "is_champ": t["is_champ"],
+            "auto_bid": t["auto_bid"],
+            "bid_pct": st["bid_pct"],
+            "avg_seed": st["avg_seed"],
+            "conf_title_pct": st["conf_title_pct"],
+            "title_pct": st["title_pct"],
+            "proj_wins": st["proj_wins"],
+        })
+
+    in_field = {t["team_id"] for t in seeded}
+    consensus = [st for st in ranked_by_bid if st["team_id"] not in in_field]
+
+    bubble = [
+        {"team_id": s["team_id"], "name": s["team_name"], "elo": s["elo_rating"],
+         "conference_name": s["conference_name"], "bid_pct": s["bid_pct"],
+         "avg_seed": s["avg_seed"], "conf_title_pct": s["conf_title_pct"],
+         "title_pct": s["title_pct"], "proj_wins": s["proj_wins"]}
+        for s in consensus[:BUBBLE_SIZE]
+    ]
+
+    return {
+        "season": season,
+        "field": seeded,
+        "bubble": bubble,
+        "runs": agg["runs"],
+        "method": "monte_carlo",
+        "through_week": inputs.through_week,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        **run_bracket(seeded),
+    }
+
+
+# ── Cache: the simulation is too slow to run inside a request ────────────────
+
+
+def refresh_projection(
+    db: Session, season: int, runs: int = DEFAULT_RUNS, seed: Optional[int] = None
+) -> dict:
+    """Simulate the season and store the result, replacing any row for this week.
+
+    Called by the weekly import once new results have landed, and by
+    ``scripts/simulate_season.py`` on demand.
+    """
+    projection = build_projection(db, season, runs=runs, seed=seed)
+    week = projection["through_week"]
+
+    db.query(PlayoffSimulation).filter(
+        PlayoffSimulation.season == season, PlayoffSimulation.week == week
+    ).delete()
+    db.add(
+        PlayoffSimulation(
+            season=season,
+            week=week,
+            runs=projection["runs"],
+            payload=json.dumps(projection),
+        )
+    )
+    db.commit()
+    logger.info(
+        "Stored playoff simulation for %s week %s (%s runs)", season, week, projection["runs"]
+    )
+    return projection
+
+
+def load_cached_projection(db: Session, season: int, week: Optional[int] = None) -> Optional[dict]:
+    """Return the stored projection for a season/week, or None if there is none.
+
+    With no `week`, returns the most recently simulated week for that season.
+    """
+    query = db.query(PlayoffSimulation).filter(PlayoffSimulation.season == season)
+    if week is not None:
+        query = query.filter(PlayoffSimulation.week == week)
+    row = query.order_by(PlayoffSimulation.week.desc()).first()
+    return json.loads(row.payload) if row else None

--- a/src/importers/pipeline.py
+++ b/src/importers/pipeline.py
@@ -254,6 +254,22 @@ Examples:
     # ranking_service already created above for conference championships
     ranking_service.save_weekly_rankings(season, final_week)
 
+    # Refresh the Monte Carlo playoff projection off the ratings just written.
+    # Takes a few seconds, so it is cached here rather than run per request.
+    # A simulation failure must never fail the import — the projection endpoint
+    # falls back to the deterministic current-ratings bracket.
+    try:
+        from src.core.season_simulation import DEFAULT_RUNS, refresh_projection
+
+        print(f"Simulating {DEFAULT_RUNS:,} seasons for the playoff projection...")
+        projection = refresh_projection(db, season)
+        if projection["field"]:
+            print(f"✓ Projected champion: {projection['champion']['name']}")
+        else:
+            print("⚠️  Not enough teams for a playoff field — projection skipped")
+    except Exception as e:  # noqa: BLE001 - never break the import over a projection
+        print(f"⚠️  Playoff simulation failed (projection will fall back): {e}")
+
     # Show final rankings
     print("\n" + "=" * 80)
     print("FINAL RANKINGS")

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -42,6 +42,7 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Text,
     UniqueConstraint,
 )
 from sqlalchemy.ext.declarative import declarative_base
@@ -748,3 +749,39 @@ class APPollRanking(Base):
     def __repr__(self):
         """Return string representation showing season, week, rank, and team."""
         return f"<APPollRanking(season={self.season}, week={self.week}, rank=#{self.rank}, team={self.team.name if self.team else 'Unknown'})>"
+
+
+class PlayoffSimulation(Base):
+    """Cached output of a Monte Carlo season simulation.
+
+    Simulating ten thousand seasons takes several seconds — too slow to do
+    inside a web request, and the answer only changes once a week when new
+    results land. So the weekly import writes the projection here as JSON and
+    the API serves it back.
+
+    Attributes:
+        season: Season year the projection covers
+        week: The week the season had reached when the simulation ran
+        runs: Number of simulated seasons behind the numbers
+        payload: The full projection as a JSON string
+        created_at: When the simulation ran
+
+    One row per (season, week); re-running a week replaces it.
+    """
+
+    __tablename__ = "playoff_simulation"
+
+    id = Column(Integer, primary_key=True, index=True)
+    season = Column(Integer, nullable=False, index=True)
+    week = Column(Integer, nullable=False, index=True)
+    runs = Column(Integer, nullable=False)
+    payload = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("season", "week", name="uq_playoff_sim_season_week"),
+    )
+
+    def __repr__(self):
+        """Return string representation showing season, week and run count."""
+        return f"<PlayoffSimulation(season={self.season}, week={self.week}, runs={self.runs})>"

--- a/tests/frontend/test_bracket_odds.js
+++ b/tests/frontend/test_bracket_odds.js
@@ -1,0 +1,99 @@
+// Self-check for the playoff odds strip under the projected bracket.
+//   node tests/frontend/test_bracket_odds.js
+//
+// board.js is an IIFE with no exports, so — like the CSS grid self-check next
+// door — this reads the source and pulls out just the functions under test.
+//
+// What it guards: the odds strip carries per-team probabilities that only exist
+// when the projection came from a Monte Carlo run. The deterministic
+// current-ratings fallback has no bid_pct, and rendering it would print a row of
+// "undefined%" under the bracket.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '../../frontend/js/board.js'), 'utf8'
+);
+
+/** Pull a top-level `function name(...) { ... }` block out of the source by
+ *  walking braces from its opening one. */
+function extract(name) {
+  const start = src.indexOf('function ' + name + '(');
+  assert.notStrictEqual(start, -1, 'missing function ' + name);
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('unbalanced braces in ' + name);
+}
+
+// Minimal stand-ins for the board helpers the odds strip leans on.
+const preamble = `
+  var esc = function (s) { return String(s); };
+  var abbrName = function (s) { return s; };
+  var stripeName = function () { return '#123456'; };
+  var host = { innerHTML: '', classList: { _v: new Set(),
+    add: function (c) { this._v.add(c); }, remove: function (c) { this._v.delete(c); },
+    has: function (c) { return this._v.has(c); } } };
+  var document = { getElementById: function () { return host; } };
+`;
+
+const sandbox = new Function(
+  preamble + extract('fmtPct') + extract('oddsRow') + extract('renderOdds') +
+  'return { fmtPct: fmtPct, renderOdds: renderOdds, host: host };'
+)();
+
+const { fmtPct, renderOdds, host } = sandbox;
+
+// ── fmtPct: one decimal below 10%, whole numbers above, em dash for missing ──
+assert.strictEqual(fmtPct(null), '—', 'absent probability must not print "null%"');
+assert.strictEqual(fmtPct(undefined), '—');
+assert.strictEqual(fmtPct(0), '0.0%');
+assert.strictEqual(fmtPct(4.26), '4.3%', 'small odds keep a decimal');
+assert.strictEqual(fmtPct(28.34), '28%', 'large odds round to whole numbers');
+assert.strictEqual(fmtPct(100), '100%');
+
+// ── renderOdds gating ──
+function team(id, seed, bid) {
+  return {
+    team_id: id, seed: seed, name: 'Team ' + id, bid_pct: bid,
+    conf_title_pct: 10, title_pct: 2,
+  };
+}
+const field = Array.from({ length: 12 }, (_, i) => team(i + 1, i + 1, 30 - i));
+const bubble = Array.from({ length: 13 }, (_, i) => team(100 + i, null, 18 - i));
+
+// The Monte Carlo payload renders.
+renderOdds({ method: 'monte_carlo', field: field, bubble: bubble });
+assert.ok(!host.classList.has('hidden'), 'simulated projection must show the strip');
+const rows = host.innerHTML.match(/class="bk-odds-row/g) || [];
+assert.strictEqual(rows.length, 12 + 8, 'twelve seeds plus eight bubble teams');
+assert.ok(host.innerHTML.includes('ON THE BUBBLE'), 'bubble section is labelled');
+assert.ok(!/undefined/.test(host.innerHTML), 'no undefined leaked into the markup');
+
+// The deterministic fallback must stay hidden rather than print empty columns.
+renderOdds({
+  method: 'current_ratings',
+  field: field.map((t) => ({ ...t, bid_pct: undefined })),
+  bubble: [],
+});
+assert.ok(host.classList.has('hidden'), 'current-ratings fallback hides the strip');
+assert.strictEqual(host.innerHTML, '', 'hidden strip is emptied, not left stale');
+
+// A monte_carlo payload that somehow lacks probabilities is also refused.
+renderOdds({ method: 'monte_carlo', field: [team(1, 1, undefined)], bubble: [] });
+assert.ok(host.classList.has('hidden'), 'missing bid_pct hides the strip');
+
+// An empty field must not throw.
+renderOdds({ method: 'monte_carlo', field: [], bubble: [] });
+assert.ok(host.classList.has('hidden'));
+
+// Bar widths stay inside the track even at 0%.
+renderOdds({ method: 'monte_carlo', field: [team(1, 1, 0)], bubble: [] });
+const widths = [...host.innerHTML.matchAll(/width:(\d+)%/g)].map((m) => Number(m[1]));
+assert.ok(widths.every((w) => w >= 1 && w <= 100), 'bar width clamped to 1-100%');
+
+console.log('bracket odds self-check passed');

--- a/tests/unit/test_season_simulation.py
+++ b/tests/unit/test_season_simulation.py
@@ -384,3 +384,19 @@ class TestBuildProjection:
             PlayoffSimulation.season == 2033
         ).count()
         assert rows == 1
+
+
+def test_every_run_awards_exactly_one_legal_field():
+    """Bids, titles and conference crowns are conserved per run.
+
+    This is the cheapest guard against an illegal field: if selection ever drops
+    an auto-bid or double-counts a team, the per-run averages stop being whole
+    numbers. A marginal probability like bid_pct cannot catch that on its own.
+    """
+    inputs = build_inputs()
+    result = ss.simulate_season(inputs, runs=50, seed=99)
+    runs = result["runs"]
+
+    assert sum(result["bid_count"]) == FIELD_SIZE * runs
+    assert sum(result["title_count"]) == runs
+    assert sum(result["conf_title_count"]) == len(CONFERENCES) * runs

--- a/tests/unit/test_season_simulation.py
+++ b/tests/unit/test_season_simulation.py
@@ -1,0 +1,386 @@
+"""Tests for the Monte Carlo season simulation that seeds the CFP bracket."""
+
+import math
+import random
+
+import pytest
+
+from src.core import season_simulation as ss
+from src.core.ranking_service import (
+    FIELD_SIZE,
+    G5_AUTO_BIDS,
+    POWER_AUTO_BIDS,
+    RankingService,
+    select_cfp_field,
+)
+
+CONFERENCES = {
+    "SEC": "P5",
+    "Big Ten": "P5",
+    "Big 12": "P5",
+    "ACC": "P5",
+    "American Athletic": "G5",
+    "Mountain West": "G5",
+}
+TEAMS_PER_CONF = 6
+
+
+def build_inputs(elo_of=None, games_per_team=8):
+    """A synthetic league: six conferences of six, each playing a conference schedule.
+
+    Built directly rather than through the database so the tests exercise the
+    simulation itself and not the loader.
+    """
+    names, tiers, conf_names, base_elo = [], [], [], []
+    conf_members = {}
+    for conf, tier in CONFERENCES.items():
+        conf_members[conf] = []
+        for j in range(TEAMS_PER_CONF):
+            i = len(names)
+            name = f"{conf} {j}"
+            names.append(name)
+            tiers.append(tier)
+            conf_names.append(conf)
+            base_elo.append(elo_of(name, conf, j) if elo_of else 1500.0)
+            conf_members[conf].append(i)
+
+    # Round-robin inside each conference, alternating who is at home.
+    games = []
+    for members in conf_members.values():
+        for a_pos, a in enumerate(members):
+            for b in members[a_pos + 1:]:
+                games.append((a, b, 5, False, True))
+                games.append((b, a, 9, False, True))
+
+    n = len(names)
+    return ss.SimInputs(
+        season=2026,
+        through_week=1,
+        team_ids=list(range(1, n + 1)),
+        names=names,
+        tiers=tiers,
+        conf_names=conf_names,
+        base_elo=base_elo,
+        eff=[None] * n,
+        wins=[0] * n,
+        losses=[0] * n,
+        conf_wins=[0] * n,
+        conf_losses=[0] * n,
+        games=games,
+        conf_members=conf_members,
+    )
+
+
+class TestEloStep:
+    """The in-memory ELO update must track RankingService.process_game."""
+
+    def test_zero_sum_within_a_tier(self):
+        inputs = build_inputs()
+        sim = ss._new_run_state(inputs)
+        before = sum(sim["elo"])
+        ss._play(sim, 0, 1, 5, False, True, random.Random(1))
+        assert sum(sim["elo"]) == pytest.approx(before)
+
+    def test_cross_tier_upset_is_not_zero_sum(self):
+        """A G5 win over a P5 pays 1.1x while the P5 only loses 0.9x."""
+        inputs = build_inputs()
+        sim = ss._new_run_state(inputs)
+        g5 = inputs.conf_names.index("American Athletic")
+        p5 = 0
+        assert inputs.tiers[g5] == "G5" and inputs.tiers[p5] == "P5"
+
+        before = sim["elo"][g5] + sim["elo"][p5]
+        rng = random.Random(0)
+        while ss._play(sim, p5, g5, 5, True, False, rng) != g5:
+            sim = ss._new_run_state(inputs)
+        assert sim["elo"][g5] + sim["elo"][p5] > before
+
+    def test_matches_process_game_arithmetic(self):
+        """Hand-compute one game and check the sim lands on the same numbers."""
+        inputs = build_inputs(elo_of=lambda name, conf, j: 1600.0 if j == 0 else 1400.0)
+        sim = ss._new_run_state(inputs)
+        home, away = 0, 1  # 1600 at home vs 1400
+
+        home_rating = 1600.0 + RankingService.HOME_FIELD_ADVANTAGE
+        expected = 1 / (1 + 10 ** ((1400.0 - home_rating) / 400))
+
+        class FixedRNG:
+            """Home team wins; margin lands exactly on the rating-implied edge."""
+
+            def random(self):
+                return 0.0  # always below the win probability → home wins
+
+            def gauss(self, mu, sigma):
+                return mu
+
+        ss._play(sim, home, away, 3, False, True, FixedRNG())  # week 3 → K=64
+
+        edge = (home_rating - 1400.0) * ss.MARGIN_PER_ELO
+        mov = min(math.log(edge + 1.0), RankingService.MAX_MOV_MULTIPLIER)
+        change = RankingService.K_FACTOR_EARLY * (1 - expected) * mov
+        assert sim["elo"][home] == pytest.approx(1600.0 + change)
+        assert sim["elo"][away] == pytest.approx(1400.0 - change)
+
+    def test_k_factor_follows_the_season(self):
+        assert ss._k_factor(1) == RankingService.K_FACTOR_EARLY
+        assert ss._k_factor(4) == RankingService.K_FACTOR_EARLY
+        assert ss._k_factor(5) == RankingService.K_FACTOR_MID
+        assert ss._k_factor(8) == RankingService.K_FACTOR_MID
+        assert ss._k_factor(9) == RankingService.K_FACTOR_LATE
+        assert ss._k_factor(14) == RankingService.K_FACTOR_LATE
+
+    def test_records_advance(self):
+        inputs = build_inputs()
+        sim = ss._new_run_state(inputs)
+        winner = ss._play(sim, 0, 1, 5, False, True, random.Random(2))
+        loser = 1 if winner == 0 else 0
+        assert sim["wins"][winner] == 1 and sim["conf_wins"][winner] == 1
+        assert sim["losses"][loser] == 1 and sim["conf_losses"][loser] == 1
+
+    def test_non_conference_game_leaves_conference_record_alone(self):
+        inputs = build_inputs()
+        sim = ss._new_run_state(inputs)
+        ss._play(sim, 0, 7, 5, True, False, random.Random(3))
+        assert sum(sim["conf_wins"]) == 0 and sum(sim["conf_losses"]) == 0
+        assert sum(sim["wins"]) == 1
+
+
+class TestConferenceChampions:
+    def test_one_champion_per_eligible_conference(self):
+        inputs = build_inputs()
+        sim = ss._new_run_state(inputs)
+        rng = random.Random(4)
+        for g in inputs.games:
+            ss._play(sim, *g, rng)
+        champions = ss._conference_champions(inputs, sim, rng)
+
+        assert len(champions) == len(CONFERENCES)
+        assert len(set(champions)) == len(CONFERENCES)
+        for champ in champions:
+            assert champ in inputs.conf_members[inputs.conf_names[champ]]
+
+    def test_undersized_conference_gets_no_champion(self):
+        """A stale two-team conference must not mint an auto-bid."""
+        inputs = build_inputs()
+        inputs.conf_members.pop("Mountain West")
+        sim = ss._new_run_state(inputs)
+        champions = ss._conference_champions(inputs, sim, random.Random(5))
+        assert len(champions) == len(CONFERENCES) - 1
+        assert all(inputs.conf_names[c] != "Mountain West" for c in champions)
+
+    def test_title_game_participants_lead_the_conference(self):
+        """The two teams playing for the title are the top two by conference record."""
+        inputs = build_inputs()
+        sim = ss._new_run_state(inputs)
+        rng = random.Random(6)
+        for g in inputs.games:
+            ss._play(sim, *g, rng)
+
+        members = inputs.conf_members["SEC"]
+        pre = {i: (sim["conf_wins"][i], sim["conf_losses"][i]) for i in members}
+        champion = [c for c in ss._conference_champions(inputs, sim, rng)
+                    if inputs.conf_names[c] == "SEC"][0]
+
+        best_two = sorted(
+            members,
+            key=lambda i: (pre[i][0] / max(pre[i][0] + pre[i][1], 1), sim["elo"][i]),
+            reverse=True,
+        )[:2]
+        assert champion in best_two
+
+
+class TestSelectCfpField:
+    """The selection rule shared by the simulation and the deterministic bracket."""
+
+    @staticmethod
+    def make_rankings(n=40):
+        rankings = []
+        for i in range(n):
+            conf = list(CONFERENCES)[i % len(CONFERENCES)]
+            rankings.append({
+                "team_id": i + 1,
+                "team_name": f"Team {i}",
+                "conference": CONFERENCES[conf],
+                "conference_name": conf,
+                "elo_rating": 1900.0 - i * 10,
+            })
+        return rankings
+
+    def test_field_is_exactly_twelve_uniquely_seeded(self):
+        rankings = self.make_rankings()
+        champs = rankings[:len(CONFERENCES)]
+        field = select_cfp_field(rankings, champs)
+        assert len(field) == FIELD_SIZE
+        assert [t["seed"] for t in field] == list(range(1, FIELD_SIZE + 1))
+        assert len({t["team_id"] for t in field}) == FIELD_SIZE
+
+    def test_seeded_strictly_by_rating(self):
+        rankings = self.make_rankings()
+        field = select_cfp_field(rankings, rankings[:len(CONFERENCES)])
+        ratings = [t["elo"] for t in field]
+        assert ratings == sorted(ratings, reverse=True)
+
+    def test_auto_bid_count(self):
+        rankings = self.make_rankings()
+        champs = rankings[:len(CONFERENCES)]
+        field = select_cfp_field(rankings, champs)
+        assert sum(t["auto_bid"] for t in field) == POWER_AUTO_BIDS + G5_AUTO_BIDS
+
+    def test_low_rated_g5_champion_still_gets_in(self):
+        """The Group-of-5 auto-bid is the whole point of the rule."""
+        rankings = self.make_rankings(n=60)
+        g5 = {
+            "team_id": 999,
+            "team_name": "Tiny G5",
+            "conference": "G5",
+            "conference_name": "Mountain West",
+            "elo_rating": 1200.0,  # nowhere near the at-large cut
+        }
+        rankings.append(g5)
+        power = [r for r in rankings if r["conference"] == "P5"][:4]
+        field = select_cfp_field(rankings, power + [g5])
+        assert 999 in {t["team_id"] for t in field}
+        assert next(t for t in field if t["team_id"] == 999)["auto_bid"] is True
+
+
+class TestSimulateSeason:
+    def test_deterministic_for_a_fixed_seed(self):
+        inputs = build_inputs()
+        a = ss.simulate_season(inputs, runs=25, seed=99)
+        b = ss.simulate_season(inputs, runs=25, seed=99)
+        assert a == b
+
+    def test_different_seeds_diverge(self):
+        inputs = build_inputs()
+        a = ss.simulate_season(inputs, runs=25, seed=1)
+        b = ss.simulate_season(inputs, runs=25, seed=2)
+        assert a["bid_count"] != b["bid_count"]
+
+    def test_every_run_awards_exactly_twelve_bids(self):
+        runs = 40
+        inputs = build_inputs()
+        agg = ss.simulate_season(inputs, runs=runs, seed=11)
+        assert sum(agg["bid_count"]) == FIELD_SIZE * runs
+
+    def test_every_run_crowns_one_champion_per_conference(self):
+        runs = 40
+        inputs = build_inputs()
+        agg = ss.simulate_season(inputs, runs=runs, seed=12)
+        assert sum(agg["conf_title_count"]) == len(CONFERENCES) * runs
+        assert sum(agg["title_count"]) == runs
+
+    def test_stronger_teams_earn_more_bids(self):
+        """A clearly better team should reach the field far more often."""
+        inputs = build_inputs(
+            elo_of=lambda name, conf, j: 1900.0 if j == 0 else 1350.0
+        )
+        agg = ss.simulate_season(inputs, runs=120, seed=13)
+        strong = [i for i, n in enumerate(inputs.names) if n.endswith(" 0")]
+        weak = [i for i in range(len(inputs.names)) if i not in strong]
+        assert min(agg["bid_count"][i] for i in strong) > max(agg["bid_count"][i] for i in weak)
+
+    def test_records_never_exceed_games_played(self):
+        inputs = build_inputs()
+        runs = 10
+        agg = ss.simulate_season(inputs, runs=runs, seed=14)
+        games_each = 2 * (TEAMS_PER_CONF - 1)
+        # Every team also plays its conference title game in the runs it reaches one.
+        assert max(agg["win_sum"]) <= (games_each + 1) * runs
+
+
+class TestBuildProjection:
+    """End-to-end payload shape, exercised against the real database session."""
+
+    def test_payload_is_a_legal_field(self, db_session):
+        from src.models.models import ConferenceType, Season, Team
+
+        db_session.add(Season(year=2031, current_week=1, is_active=False))
+        teams = []
+        for conf, tier in CONFERENCES.items():
+            for j in range(TEAMS_PER_CONF):
+                t = Team(
+                    name=f"{conf} {j}",
+                    conference=(
+                        ConferenceType.POWER_5 if tier == "P5" else ConferenceType.GROUP_5
+                    ),
+                    conference_name=conf,
+                    is_fcs=False,
+                    elo_rating=1500.0 + (TEAMS_PER_CONF - j) * 30,
+                )
+                teams.append(t)
+                db_session.add(t)
+        db_session.commit()
+
+        projection = ss.build_projection(db_session, 2031, runs=30, seed=21)
+
+        assert projection["method"] == "monte_carlo"
+        assert projection["runs"] == 30
+        assert len(projection["field"]) == FIELD_SIZE
+        assert [t["seed"] for t in projection["field"]] == list(range(1, FIELD_SIZE + 1))
+        assert sum(t["auto_bid"] for t in projection["field"]) == POWER_AUTO_BIDS + G5_AUTO_BIDS
+
+        # Probabilities are present and sane.
+        for t in projection["field"]:
+            assert 0.0 <= t["bid_pct"] <= 100.0
+            assert 0.0 <= t["conf_title_pct"] <= 100.0
+            assert t["avg_seed"] is not None
+
+        # The bubble is disjoint from the field.
+        field_ids = {t["team_id"] for t in projection["field"]}
+        assert not field_ids & {b["team_id"] for b in projection["bubble"]}
+
+        # The bracket ran.
+        assert len(projection["first_round"]) == 4
+        assert len(projection["quarterfinals"]) == 4
+        assert len(projection["semifinals"]) == 2
+        assert projection["champion"]["team_id"] in field_ids
+
+    def test_cache_round_trip(self, db_session):
+        from src.models.models import ConferenceType, Season, Team
+
+        db_session.add(Season(year=2032, current_week=3, is_active=False))
+        for conf, tier in CONFERENCES.items():
+            for j in range(TEAMS_PER_CONF):
+                db_session.add(Team(
+                    name=f"{conf} {j}",
+                    conference=(
+                        ConferenceType.POWER_5 if tier == "P5" else ConferenceType.GROUP_5
+                    ),
+                    conference_name=conf,
+                    is_fcs=False,
+                    elo_rating=1500.0 + (TEAMS_PER_CONF - j) * 30,
+                ))
+        db_session.commit()
+
+        assert ss.load_cached_projection(db_session, 2032) is None
+        stored = ss.refresh_projection(db_session, 2032, runs=20, seed=31)
+        cached = ss.load_cached_projection(db_session, 2032)
+
+        assert cached is not None
+        assert cached["runs"] == stored["runs"] == 20
+        assert cached["through_week"] == 3
+        assert [t["team_id"] for t in cached["field"]] == [t["team_id"] for t in stored["field"]]
+
+    def test_refresh_replaces_rather_than_duplicates(self, db_session):
+        from src.models.models import ConferenceType, PlayoffSimulation, Season, Team
+
+        db_session.add(Season(year=2033, current_week=2, is_active=False))
+        for conf, tier in CONFERENCES.items():
+            for j in range(TEAMS_PER_CONF):
+                db_session.add(Team(
+                    name=f"{conf} {j}",
+                    conference=(
+                        ConferenceType.POWER_5 if tier == "P5" else ConferenceType.GROUP_5
+                    ),
+                    conference_name=conf,
+                    is_fcs=False,
+                    elo_rating=1500.0,
+                ))
+        db_session.commit()
+
+        ss.refresh_projection(db_session, 2033, runs=10, seed=1)
+        ss.refresh_projection(db_session, 2033, runs=10, seed=2)
+        rows = db_session.query(PlayoffSimulation).filter(
+            PlayoffSimulation.season == 2033
+        ).count()
+        assert rows == 1


### PR DESCRIPTION
Two changes that belong together: the projected playoff bracket now comes from a
Monte Carlo simulation of the season rather than today's ratings, and the
preseason formula was retuned so those ratings are spread widely enough for the
simulation to say anything useful.

## Monte Carlo bracket (e69de4b)

`project_playoff_bracket()` seeded the bracket off a `ranking_history` snapshot
at the current week — in Week 1 that is a preseason-ratings bracket wearing a
playoff costume, with no schedule, no records, and no sense of likelihood.

`src/core/season_simulation.py` simulates the remaining season 10,000 times,
evolving Elo through every simulated game, and reports playoff bid %, average
seed, conference title % and championship %. Results are cached as JSON in a new
`playoff_simulation` table; `GET /api/playoff-projection` serves the cache and
falls back to the old deterministic path when no row exists (tell them apart by
the payload's `method`). The weekly import refreshes it.

Three things worth knowing:

- **Conference championship games do not exist in the schedule.** CFBD only
  publishes them in weeks 14-15 once matchups are known, so the simulation
  synthesizes them from top-2 conference record at a neutral site.
- **The rendered bracket is a consensus field, not a modal one.** No exact
  12-team field recurs often enough at 10k runs to be meaningful. The consensus
  field is routed back through the real auto-bid rule, because averaging bid
  probabilities alone produces an *illegal* bracket — the five auto-bids do not
  survive the averaging.
- **Simulation never touches the DB.** `process_game` commits, mutates ORM
  objects and rejects `excluded_from_rankings` rows (which all 886 future 2026
  games carry), so the sim mirrors its arithmetic over plain dicts instead.

## Preseason retune (13bc2d9)

The simulation immediately exposed that preseason ratings were ~3x too
compressed: stdev 47 against a real end-of-season 143-177. Every game came out
near a coin flip and the best team projected a 28% bid on 6.5-8.0 wins.

The cause was the previous-season term, not the sim — an effective shrink of
0.35 * 0.60 = 0.21, where a chained 2021-2025 replay (4 season pairs, 528
team-seasons, 3080 scored games) puts the optimum near 0.75. Retuned to
`previous_season_weight` 0.60, `mean_regression_factor` 0.75,
`returning_regression_scale` 0.45, and widened the regression clamp ceiling from
0.85 to 0.95 — 18 of 135 teams were pinned at the old ceiling, precisely the
teams returning the most production.

Returning production earns its keep: pooled across four season pairs the
interaction fits at +0.29 (se 0.171, t = +1.70). Real, and small.

| | before | after |
|---|---|---|
| preseason stdev | 47.2 | 97.8 |
| effective carryover | 0.105-0.297 | 0.315-0.570 |
| top team bid% | 28.3 | 70.3 |
| top proj. wins | 6.5-8.0 | 8.1-9.9 |

## Deploying

Not a plain code deploy. In order: `migrations/migrate_add_playoff_simulation.py`
for the new table, then re-run the preseason initialization (the config change
alone moves nothing — `teams.elo_rating` only changes when the preseason
recalculates), then `scripts/simulate_season.py --season 2026 --runs 10000`.
Back up the database first; the re-init rewrites `elo_rating` for all 135 FBS
teams.

## Testing

853 passing (`-m "not e2e"`), 23 of them new in
`tests/unit/test_season_simulation.py` — the bracket feature previously had
none. Includes a per-run conservation check (exactly 12 bids, 1 title, 9
conference crowns), which is the invariant that catches the illegal-field bug
class; marginal probabilities like bid_pct cannot.

E2E were not run: Playwright's Chromium will not launch on macOS 27, which also
breaks the repo's existing e2e suite. Frontend changes were verified with a Node
self-check against `board.js` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)