### PR TITLE
fix: make the E2E job actually test something

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,11 +44,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      # Install Playwright browsers for E2E tests
-      - name: Install Playwright browsers
-        run: |
-          python -m playwright install chromium
-
       # Run unit tests
       - name: Run unit tests
         run: |
@@ -84,13 +79,13 @@ jobs:
             .coverage
           retention-days: 7
 
-  # Optional: E2E tests job (runs separately, requires server)
+  # Browser-driven tests. Slower than the suite above, so they run in their
+  # own job after it passes.
   e2e-test:
     name: Run E2E Tests
     runs-on: ubuntu-latest
     needs: test  # Only run if unit/integration tests pass
     timeout-minutes: 30  # Prevent hung tests from running forever
-    continue-on-error: true  # Don't fail CI if E2E tests fail/timeout
 
     steps:
       - name: Checkout repository
@@ -105,73 +100,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
-          python -m playwright install chromium
 
-      # Create and seed test database for E2E tests
-      - name: Setup test database
-        run: |
-          python3 << 'EOF'
-          # Paths are src.* since the restructure — the old top-level
-          # `from database import ...` died with ModuleNotFoundError on every
-          # run, so the E2E job never actually reached the tests.
-          from src.models.database import Base, engine, SessionLocal
-          from src.models.models import Season, Team, ConferenceType
+      # --with-deps pulls the system libraries the bundled Chromium needs on
+      # the runner image; without it the browser fails to launch.
+      - name: Install Playwright browsers
+        run: python -m playwright install --with-deps chromium
 
-          # Create tables
-          Base.metadata.create_all(bind=engine)
-
-          # Seed minimal data
-          db = SessionLocal()
-          try:
-              # Add current season
-              season = Season(
-                  year=2024,
-                  is_active=True,
-                  current_week=10
-              )
-              db.add(season)
-
-              # Add a few test teams
-              teams = [
-                  Team(name="Alabama", conference=ConferenceType.POWER_5, is_fcs=False, elo_rating=1800.0),
-                  Team(name="Georgia", conference=ConferenceType.POWER_5, is_fcs=False, elo_rating=1780.0),
-                  Team(name="Ohio State", conference=ConferenceType.POWER_5, is_fcs=False, elo_rating=1750.0),
-              ]
-              for team in teams:
-                  db.add(team)
-
-              db.commit()
-              print("✓ Test database seeded successfully")
-          finally:
-              db.close()
-          EOF
-
-      # Start FastAPI server in background
-      - name: Start FastAPI server
-        run: |
-          python3 main.py &
-          # Wait for server to be ready (max 30 seconds)
-          for i in {1..30}; do
-            if curl -s http://localhost:8000/ > /dev/null 2>&1; then
-              echo "Server is ready!"
-              break
-            fi
-            echo "Waiting for server... ($i/30)"
-            sleep 1
-          done
-        env:
-          PYTHONUNBUFFERED: 1
-
-      # Run E2E tests
+      # The live_server fixture starts the app itself on port 8765 and the
+      # test_db fixture points it at the per-test SQLite database, so there is
+      # no server to launch or database to seed here.
       - name: Run E2E tests
-        run: |
-          pytest -m e2e -v --tb=short
-
-      # Take screenshots on failure
-      - name: Archive E2E screenshots
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-screenshots
-          path: screenshots/
-          retention-days: 7
+        run: pytest -m e2e -v --tb=short

--- a/frontend/team.html
+++ b/frontend/team.html
@@ -216,6 +216,5 @@
   <script src="js/date-utils.js"></script>
   <script src="js/share.js"></script>
   <script src="js/season.js"></script>
-  <script src="js/team.js"></script>
 </body>
 </html>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ httpx==0.28.1              # Required by FastAPI TestClient (upgraded for Starle
 factory-boy==3.3.0         # Test data factories
 
 # Frontend E2E Testing
-playwright==1.40.0         # Browser automation for E2E tests
+playwright==1.62.0         # Browser automation for E2E tests
 
 # Test Utilities
 pytest-xdist==3.5.0        # Parallel test execution

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,23 @@ def test_db():
     # Create session
     db = TestingSessionLocal()
 
+    # Point the app at this database too. E2E tests seed through `test_db` but
+    # read the result back through a real HTTP request to the live server, which
+    # otherwise hits the developer's cfb_rankings.db and never sees the fixture
+    # data. A fresh session per request keeps the server thread off `db`.
+    def override_get_db():
+        request_db = TestingSessionLocal()
+        try:
+            yield request_db
+        finally:
+            request_db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
     try:
         yield db
     finally:
+        app.dependency_overrides.pop(get_db, None)
         db.close()
         # Drop all tables after test
         Base.metadata.drop_all(bind=engine)
@@ -283,6 +297,7 @@ def live_server():
     Yields:
         str: Base URL of the running server (e.g., "http://localhost:8765")
     """
+    import socket
     import threading
     import time
 
@@ -292,7 +307,7 @@ def live_server():
 
     # Use a different port for E2E tests to avoid conflicts
     test_port = 8765
-    base_url = f"http://localhost:{test_port}"
+    base_url = f"http://127.0.0.1:{test_port}"
 
     # Start server in background thread
     config = uvicorn.Config(app, host="127.0.0.1", port=test_port, log_level="error")
@@ -304,8 +319,16 @@ def live_server():
     thread = threading.Thread(target=run_server, daemon=True)
     thread.start()
 
-    # Wait for server to start
-    time.sleep(2)
+    # Wait for the server to accept connections. A fixed sleep is either slow or
+    # (on a loaded CI runner) too short, which shows up as a flaky first test.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        with socket.socket() as probe:
+            if probe.connect_ex(("127.0.0.1", test_port)) == 0:
+                break
+        time.sleep(0.1)
+    else:
+        raise RuntimeError(f"E2E server did not start on port {test_port}")
 
     yield base_url
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,49 @@
+"""Shared seeding helper for the browser-driven E2E tests.
+
+Since EPIC-024 the rankings board is served from ``ranking_history`` rows rather
+than the ``teams`` table, so a test that only inserts ``Team`` records renders an
+empty board no matter what ELO it set. ``seed_board`` inserts the season, the
+teams, and the matching week snapshot together.
+"""
+
+import pytest
+
+from src.models.models import RankingHistory, Season
+
+
+@pytest.fixture
+def seed_board(test_db):
+    """Return a callable that seeds Team rows plus the ranking snapshot behind them.
+
+    Usage:
+        alabama = Team(name="Alabama", conference=ConferenceType.POWER_5, ...)
+        seed_board(alabama)
+
+    Ranks are assigned by ELO descending, matching what the ranking service
+    would produce for a real week.
+    """
+
+    def _seed(*teams, year=2024, week=5):
+        test_db.add(Season(year=year, current_week=week, is_active=True))
+        test_db.add_all(teams)
+        test_db.flush()  # assign team ids
+
+        for rank, team in enumerate(
+            sorted(teams, key=lambda t: t.elo_rating, reverse=True), start=1
+        ):
+            test_db.add(
+                RankingHistory(
+                    team_id=team.id,
+                    season=year,
+                    week=week,
+                    rank=rank,
+                    elo_rating=team.elo_rating,
+                    wins=team.wins,
+                    losses=team.losses,
+                )
+            )
+
+        test_db.commit()
+        return teams
+
+    return _seed

--- a/tests/e2e/test_comparison_page.py
+++ b/tests/e2e/test_comparison_page.py
@@ -42,7 +42,7 @@ class TestComparisonPageLoad:
         # Assert - Header is visible
         header = page.locator("h1")
         expect(header).to_be_visible()
-        expect(header).to_contain_text("Comparison")
+        expect(header).to_contain_text("Prediction Accuracy")
 
     def test_page_has_navigation(self, browser_page):
         """Test that page has navigation menu"""

--- a/tests/e2e/test_predictions_workflow.py
+++ b/tests/e2e/test_predictions_workflow.py
@@ -42,7 +42,7 @@ class TestPredictionsPageLoad:
         # Assert - Header is visible
         header = page.locator("h1")
         expect(header).to_be_visible()
-        expect(header).to_contain_text("Games")
+        expect(header).to_contain_text("Game Schedule")
 
     def test_page_has_navigation(self, browser_page):
         """Test that page has navigation menu"""

--- a/tests/e2e/test_rankings_page.py
+++ b/tests/e2e/test_rankings_page.py
@@ -7,13 +7,9 @@ Tests verify the full stack works together:
 - Data is rendered correctly in the DOM
 - User interactions work as expected
 
-NOTE: These E2E tests require a running FastAPI server.
-Run manually with: pytest tests/e2e/ -v
-Or skip E2E tests with: pytest -m "not e2e"
-
-To run E2E tests:
-1. Start the FastAPI server: python3 main.py (in another terminal)
-2. Run: pytest tests/e2e/ -v
+The `live_server` fixture starts the app itself, so no separate server is
+needed: run `pytest tests/e2e/ -v`, or skip these with `pytest -m "not e2e"`.
+Chromium must be installed once via `python -m playwright install chromium`.
 """
 
 import pytest
@@ -61,9 +57,11 @@ class TestRankingsPageLoad:
         # Act
         page.goto(f"{base_url}/frontend/index.html")
 
-        # Assert - Navigation links are present
-        nav_links = page.locator("nav a")
-        expect(nav_links).to_have_count(7)  # Rankings, Teams, Games, Compare, etc.
+        # Assert - The main navigation destinations are present. Asserting the
+        # link names rather than a count means adding a page to layout.js does
+        # not fail this test, but dropping one of these does.
+        for name in ("Rankings", "Games", "Compare"):
+            expect(page.locator("nav a", has_text=name)).to_be_visible()
 
 
 @pytest.mark.e2e
@@ -71,25 +69,20 @@ class TestRankingsPageLoad:
 class TestRankingsTableDisplay:
     """Tests for rankings table rendering with API data"""
 
-    def test_rankings_table_displays(self, browser_page, test_db):
+    def test_rankings_table_displays(self, browser_page, seed_board):
         """Test that rankings table is rendered"""
         # Arrange
         page, base_url = browser_page
-        from src.models.models import ConferenceType, Season, Team
+        from src.models.models import ConferenceType, Team
 
         # Create test data
-        season = Season(year=2024, current_week=5, is_active=True)
-        test_db.add(season)
-
         team1 = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
         )
         team2 = Team(
             name="Georgia", conference=ConferenceType.POWER_5, elo_rating=1840.0, wins=4, losses=1
         )
-        test_db.add(team1)
-        test_db.add(team2)
-        test_db.commit()
+        seed_board(team1, team2)
 
         # Act - Load page and wait for data to load
         page.goto(f"{base_url}/frontend/index.html")
@@ -99,20 +92,16 @@ class TestRankingsTableDisplay:
         table_rows = page.locator(".tkr-row")
         expect(table_rows).to_have_count(2, timeout=5000)
 
-    def test_rankings_table_shows_correct_data(self, browser_page, test_db):
+    def test_rankings_table_shows_correct_data(self, browser_page, seed_board):
         """Test that rankings table displays team data correctly"""
         # Arrange
         page, base_url = browser_page
-        from src.models.models import ConferenceType, Season, Team
-
-        season = Season(year=2024, current_week=1, is_active=True)
-        test_db.add(season)
+        from src.models.models import ConferenceType, Team
 
         alabama = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=1, losses=0
         )
-        test_db.add(alabama)
-        test_db.commit()
+        seed_board(alabama, week=1)
 
         # Act
         page.goto(f"{base_url}/frontend/index.html")
@@ -124,14 +113,11 @@ class TestRankingsTableDisplay:
         expect(first_row).to_contain_text("1850")
         expect(first_row).to_contain_text("1-0")
 
-    def test_rankings_sorted_by_elo(self, browser_page, test_db):
+    def test_rankings_sorted_by_elo(self, browser_page, seed_board):
         """Test that teams are sorted by ELO rating descending"""
         # Arrange
         page, base_url = browser_page
-        from src.models.models import ConferenceType, Season, Team
-
-        season = Season(year=2024, is_active=True)
-        test_db.add(season)
+        from src.models.models import ConferenceType, Team
 
         # Create teams in mixed order
         team3 = Team(
@@ -148,8 +134,7 @@ class TestRankingsTableDisplay:
             name="Georgia", conference=ConferenceType.POWER_5, elo_rating=1840.0, wins=3, losses=0
         )
 
-        test_db.add_all([team3, team1, team2])
-        test_db.commit()
+        seed_board(team3, team1, team2)
 
         # Act
         page.goto(f"{base_url}/frontend/index.html")
@@ -161,14 +146,11 @@ class TestRankingsTableDisplay:
         expect(rows.nth(1)).to_contain_text("Georgia")
         expect(rows.nth(2)).to_contain_text("Ohio State")
 
-    def test_conference_displayed(self, browser_page, test_db):
+    def test_conference_displayed(self, browser_page, seed_board):
         """Test that team conference is displayed"""
         # Arrange
         page, base_url = browser_page
-        from src.models.models import ConferenceType, Season, Team
-
-        season = Season(year=2024, is_active=True)
-        test_db.add(season)
+        from src.models.models import ConferenceType, Team
 
         team = Team(
             name="Boise State",
@@ -177,8 +159,7 @@ class TestRankingsTableDisplay:
             wins=5,
             losses=0,
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Act
         page.goto(f"{base_url}/frontend/index.html")
@@ -194,20 +175,16 @@ class TestRankingsTableDisplay:
 class TestRankingsPageInteractions:
     """Tests for user interactions on rankings page"""
 
-    def test_click_team_navigates_to_detail(self, browser_page, test_db):
+    def test_click_team_navigates_to_detail(self, browser_page, seed_board):
         """Test clicking a team name navigates to team detail page"""
         # Arrange
         page, base_url = browser_page
-        from src.models.models import ConferenceType, Season, Team
-
-        season = Season(year=2024, is_active=True)
-        test_db.add(season)
+        from src.models.models import ConferenceType, Team
 
         alabama = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
         )
-        test_db.add(alabama)
-        test_db.commit()
+        seed_board(alabama)
 
         # Act - Navigate to rankings and click team
         page.goto(f"{base_url}/frontend/index.html")

--- a/tests/e2e/test_team_detail.py
+++ b/tests/e2e/test_team_detail.py
@@ -17,7 +17,7 @@ from playwright.sync_api import Page, expect
 class TestTeamDetailPageLoad:
     """Tests for team detail page loading"""
 
-    def test_team_detail_page_loads(self, browser_page, test_db):
+    def test_team_detail_page_loads(self, browser_page, seed_board):
         """Test that team detail page loads successfully"""
         # Arrange
         page, base_url = browser_page
@@ -26,8 +26,7 @@ class TestTeamDetailPageLoad:
         team = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Act - Navigate to team detail page
         page.goto(f"{base_url}/frontend/team.html?id={team.id}")
@@ -36,7 +35,7 @@ class TestTeamDetailPageLoad:
         # Assert - Page loads
         expect(page).to_have_title("Stat·urday — Power Ratings")
 
-    def test_team_name_displayed(self, browser_page, test_db):
+    def test_team_name_displayed(self, browser_page, seed_board):
         """Test that team name is displayed on page"""
         # Arrange
         page, base_url = browser_page
@@ -45,16 +44,13 @@ class TestTeamDetailPageLoad:
         team = Team(
             name="Georgia", conference=ConferenceType.POWER_5, elo_rating=1840.0, wins=4, losses=1
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Act
         page.goto(f"{base_url}/frontend/team.html?id={team.id}")
-        page.wait_for_timeout(1000)
 
-        # Assert - Team name is visible
-        page_content = page.content()
-        assert "Georgia" in page_content
+        # Assert - Team name is visible in the detail panel
+        expect(page.locator("#tkr-detail")).to_contain_text("Georgia")
 
 
 @pytest.mark.e2e
@@ -62,7 +58,7 @@ class TestTeamDetailPageLoad:
 class TestTeamDetailData:
     """Tests for team detail data display"""
 
-    def test_team_stats_displayed(self, browser_page, test_db):
+    def test_team_stats_displayed(self, browser_page, seed_board):
         """Test that team stats are displayed correctly"""
         # Arrange
         page, base_url = browser_page
@@ -71,26 +67,23 @@ class TestTeamDetailData:
         team = Team(
             name="Ohio State",
             conference=ConferenceType.POWER_5,
-            elo_rating=1830.5,
+            elo_rating=1830.0,  # whole number: the board renders Math.round(elo)
             wins=7,
             losses=2,
             recruiting_rank=3,
             returning_production=0.75,
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Act
         page.goto(f"{base_url}/frontend/team.html?id={team.id}")
-        page.wait_for_timeout(1500)
-
-        page_content = page.content()
 
         # Assert - Stats are shown
-        assert "1830" in page_content or "1831" in page_content  # ELO rating (rounded)
-        assert "7-2" in page_content or "7" in page_content  # Record
+        detail = page.locator("#tkr-detail")
+        expect(detail).to_contain_text("1830")  # ELO rating (rounded)
+        expect(detail).to_contain_text("7")  # Record
 
-    def test_conference_displayed(self, browser_page, test_db):
+    def test_conference_displayed(self, browser_page, seed_board):
         """Test that team conference is displayed"""
         # Arrange
         page, base_url = browser_page
@@ -103,17 +96,13 @@ class TestTeamDetailData:
             wins=8,
             losses=1,
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Act
         page.goto(f"{base_url}/frontend/team.html?id={team.id}")
-        page.wait_for_timeout(1000)
-
-        page_content = page.content()
 
         # Assert - Conference is shown
-        assert "G5" in page_content or "Group" in page_content
+        expect(page.locator("#tkr-detail")).to_contain_text("G5")
 
 
 @pytest.mark.e2e
@@ -121,7 +110,7 @@ class TestTeamDetailData:
 class TestTeamSchedule:
     """Tests for team schedule/games display"""
 
-    def test_schedule_table_exists(self, browser_page, test_db):
+    def test_schedule_table_exists(self, browser_page, test_db, seed_board):
         """Test that schedule table is rendered"""
         # Arrange
         page, base_url = browser_page
@@ -133,8 +122,7 @@ class TestTeamSchedule:
         away_team = Team(
             name="Georgia", conference=ConferenceType.POWER_5, elo_rating=1840.0, wins=0, losses=1
         )
-        test_db.add_all([home_team, away_team])
-        test_db.commit()
+        seed_board(home_team, away_team)
 
         # Create a game
         game = Game(
@@ -162,7 +150,7 @@ class TestTeamSchedule:
             or "Georgia" in page_content
         )
 
-    def test_schedule_shows_opponent(self, browser_page, test_db):
+    def test_schedule_shows_opponent(self, browser_page, test_db, seed_board):
         """Test that schedule shows opponent name"""
         # Arrange
         page, base_url = browser_page
@@ -180,8 +168,7 @@ class TestTeamSchedule:
             wins=0,
             losses=1,
         )
-        test_db.add_all([home_team, away_team])
-        test_db.commit()
+        seed_board(home_team, away_team)
 
         game = Game(
             home_team_id=home_team.id,
@@ -198,13 +185,11 @@ class TestTeamSchedule:
 
         # Act - View Michigan's schedule
         page.goto(f"{base_url}/frontend/team.html?id={home_team.id}")
-        page.wait_for_timeout(2000)
 
-        page_content = page.content()
-
-        # Assert - Opponent name appears
-        assert "Ohio State" in page_content
-        assert "42" in page_content  # Score shown
+        # Assert - Opponent name and score appear in the results log
+        results = page.locator("#tkr-log")
+        expect(results).to_contain_text("Ohio State")
+        expect(results).to_contain_text("42")
 
 
 @pytest.mark.e2e
@@ -212,7 +197,7 @@ class TestTeamSchedule:
 class TestTeamDetailNavigation:
     """Tests for navigation on team detail page"""
 
-    def test_back_to_rankings_link_works(self, browser_page, test_db):
+    def test_back_to_rankings_link_works(self, browser_page, seed_board):
         """Test that navigation back to rankings page works"""
         # Arrange
         page, base_url = browser_page
@@ -221,8 +206,7 @@ class TestTeamDetailNavigation:
         team = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Act - Navigate to team detail, then click back to rankings
         page.goto(f"{base_url}/frontend/team.html?id={team.id}")
@@ -254,7 +238,7 @@ class TestTeamDetailNavigation:
 class TestTeamDetailAPIIntegration:
     """Tests verifying API integration on team detail page"""
 
-    def test_api_calls_made_on_load(self, browser_page, test_db):
+    def test_api_calls_made_on_load(self, browser_page, seed_board):
         """Test that page makes API calls for team data and schedule"""
         # Arrange
         page, base_url = browser_page
@@ -263,8 +247,7 @@ class TestTeamDetailAPIIntegration:
         team = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
         )
-        test_db.add(team)
-        test_db.commit()
+        seed_board(team)
 
         # Track API requests
         api_requests = []
@@ -277,27 +260,24 @@ class TestTeamDetailAPIIntegration:
 
         # Act
         page.goto(f"{base_url}/frontend/team.html?id={team.id}")
-        page.wait_for_timeout(2000)
+        expect(page.locator("#tkr-detail")).to_be_visible()
+        page.wait_for_timeout(1000)  # let the detail panel's follow-up calls fire
 
         # Assert - API calls were made
         assert len(api_requests) > 0
-        # Should call /api/teams/{id} and possibly /api/teams/{id}/schedule
-        assert any(f"/teams/{team.id}" in url for url in api_requests)
+        # The detail panel pulls the team's schedule to build the results log
+        assert any(f"/teams/{team.id}" in url for url in api_requests), api_requests
 
-    def test_full_user_workflow_rankings_to_team(self, browser_page, test_db):
+    def test_full_user_workflow_rankings_to_team(self, browser_page, seed_board):
         """Test complete user workflow: rankings -> team detail -> back"""
         # Arrange
         page, base_url = browser_page
-        from src.models.models import ConferenceType, Season, Team
-
-        season = Season(year=2024, is_active=True)
-        test_db.add(season)
+        from src.models.models import ConferenceType, Team
 
         alabama = Team(
             name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
         )
-        test_db.add(alabama)
-        test_db.commit()
+        seed_board(alabama)
 
         # Act - Start at rankings
         page.goto(f"{base_url}/frontend/index.html")


### PR DESCRIPTION
The e2e-test job carried continue-on-error, so it reported success no
matter what happened inside it. Underneath that, nothing worked:

- playwright was pinned at 1.40.0, whose bundled Chromium no longer
  launches. Bumped to 1.62.0, and `playwright install` now runs with
  --with-deps so the runner has the system libraries it needs.
- test_db built an in-memory SQLite but never overrode get_db, so the
  live server answered from the developer's cfb_rankings.db. Tests
  seeded Alabama and asserted against whatever real teams happened to
  be sitting in that file. The fixture now installs the override and
  hands each request its own session.
- Rankings have come from ranking_history rather than the teams table
  since EPIC-024, so seeding a Team alone renders an empty board. The
  new seed_board fixture inserts the season, the teams, and the week
  snapshot together.
- Several assertions still described an older frontend: the nav has six
  links rather than seven, the comparison and games headings were
  renamed, and team.html now redirects into the index.html detail
  panel.

Also drops the workflow steps that had nothing to do: the port-8000
server (the live_server fixture serves its own on 8765), the seeding
heredoc that wrote into cfb_rankings.db, and the screenshot artifact
for a directory nothing writes. live_server polls the port instead of
sleeping a fixed two seconds, which is what made the first test flaky
on a loaded runner.

frontend/team.html still loaded js/team.js, deleted back in 46c4221.

46 E2E tests pass; the other 855 are unaffected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
