### PR TITLE
fix: make the E2E job actually test something

### DIFF
--- a/scripts/check_schema.py
+++ b/scripts/check_schema.py
@@ -8,8 +8,13 @@ before restarting, so the failure shows up as a list instead of a traceback.
 Exits non-zero when something is missing, so it can gate a deploy script.
 """
 
+import os
 import sqlite3
 import sys
+
+# Run as `python scripts/check_schema.py`, sys.path[0] is scripts/, not the
+# repo root, so `src` is not importable without this.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.models.database import DATABASE_URL
 from src.models.models import Base
@@ -20,6 +25,13 @@ def main() -> int:
         print(f"Not a SQLite database ({DATABASE_URL}) — nothing to check.")
         return 0
     path = DATABASE_URL.split("///", 1)[1]
+
+    # DATABASE_URL is relative, so a wrong cwd would have sqlite3 create an
+    # empty file here and report every table as missing. Say which file is
+    # actually absent instead.
+    if not os.path.exists(path):
+        print(f"No database at {os.path.abspath(path)} (cwd {os.getcwd()}).")
+        return 1
 
     conn = sqlite3.connect(path)
     have = {


### PR DESCRIPTION
Two fixes to CI and deploy tooling that were both silently doing nothing.

## `6b6675c` — E2E job

The `e2e-test` job carried `continue-on-error: true`, so it reported success no matter what. Behind that mask, five real defects:

- `playwright` was pinned to `1.40.0`, whose bundled Chromium dies instantly on current macOS/runner images with `TargetClosedError` — and pytest then *hangs* rather than failing.
- `test_db` never installed the `get_db` dependency override, so the live server answered from the developer's `cfb_rankings.db`. Tests seeded Alabama, the page rendered 25 unrelated real teams, and the assertions passed by accident.
- Tests seeded the `teams` table, but since EPIC-024 the board reads `ranking_history`. New `seed_board` fixture inserts the season, teams, and week snapshot together.
- `team.html` now redirects to `index.html?team=N`; the team-detail tests were rewritten against `#tkr-detail`.
- Drifted frontend expectations: nav link count, and the `<h1>` text on the comparison and games pages.

Also removed dead workflow steps (a port-8000 server the `live_server` fixture makes redundant, a DB-seeding heredoc that wrote to the wrong database, an artifact upload for screenshots nothing produced) and replaced a fixed `sleep(2)` with a socket-readiness poll, which is the usual source of a flaky first test on a loaded runner.

Dropped the dead `<script src="js/team.js">` tag from `team.html` — that file was deleted in 46c4221 and has 404'd on every page load since.

## `6012861` — schema check

`scripts/check_schema.py` imported `src` with no `sys.path` bootstrap, so `python scripts/check_schema.py` — the exact line `deploy.sh` runs — died with `ModuleNotFoundError` before checking anything. The deploy gate added in c38bac8 has been inert since it shipped; caught by running a real deploy. It also now fails loudly when the database file is absent, instead of letting sqlite3 create an empty one and reporting all eleven tables as missing.

## Verification

- `pytest -m e2e -q` → 46 passed
- `pytest -m "not e2e" -q` → 855 passed
- `check_schema.py` from the repo root → `✓ ./cfb_rankings.db matches the models.` (exit 0); from `/tmp` → clear error, exit 1, no stray file created

Prod-visible surface is one line: the removed `team.js` script tag. No migration, no change to `requirements-prod.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)