### PR TITLE
feat: put the simulation's odds on the board and the team page

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # The frontend self-checks are plain node scripts with no package.json and
+      # no dependencies — they read frontend/js and frontend/css as text and
+      # assert on it. They run before the Python suite because they finish in
+      # under a second and catch a class of grid/markup drift pytest cannot see.
+      # Globbed, so a new tests/frontend/*.js is picked up without touching this
+      # file. node ships on the runner image already.
+      - name: Run frontend self-checks
+        run: |
+          for f in tests/frontend/*.js; do
+            echo "── $f"
+            node "$f"
+          done
+
       # Set up Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -108,7 +108,7 @@
 .tkr-table { border: 1px solid var(--line); border-radius: 9px; overflow: hidden; background: var(--panel); }
 .tkr-grid {
   display: grid;
-  grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px 84px;
+  grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px 58px 62px 58px 64px 84px;
   align-items: center;
 }
 .tkr-head {
@@ -139,6 +139,9 @@
 .c-delta { font-family: var(--font-mono); font-size: 12px; font-weight: 600; }
 .c-sos { font-family: var(--font-mono); font-size: 12px; color: var(--fg2); }
 .c-sos.warn { color: var(--warn); }
+/* Monte Carlo projection columns: BID% / CONF% / NAT% / PROJ W. */
+.c-odds { font-family: var(--font-mono); font-size: 12px; color: var(--fg2); }
+.c-projw { font-family: var(--font-mono); font-size: 12px; color: var(--fg); }
 .heat { font-family: var(--font-mono); font-size: 12px; color: var(--fg); }
 .trend-pos { color: var(--pos); }
 .trend-neg { color: var(--neg); }
@@ -197,6 +200,13 @@
 .tkr-preds-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 12px; }
 .tkr-preds-title { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; margin: 0; }
 .tkr-preds-meta { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.04em; color: var(--fg3); text-transform: uppercase; }
+/* The card is a <details>, so collapsing is the browser's job — no JS. The
+   default marker is replaced with a chevron on the title to match the board. */
+.tkr-preds-card > summary { cursor: pointer; list-style: none; }
+.tkr-preds-card > summary::-webkit-details-marker { display: none; }
+.tkr-preds-title::after { content: ' \25BE'; color: var(--fg3); font-weight: 400; }
+.tkr-preds-card:not([open]) .tkr-preds-title::after { content: ' \25B8'; }
+.tkr-preds-card:not([open]) .tkr-preds-head { margin-bottom: 0; }
 .tkr-pgrid { display: grid; grid-template-columns: 1.5fr 76px 1.7fr 104px 72px; align-items: center; }
 .tkr-phead { font-family: var(--font-mono); font-size: 10px; font-weight: 600; letter-spacing: 0.05em;
   text-transform: uppercase; color: var(--fg3); border-bottom: 1px solid var(--line); }
@@ -437,6 +447,9 @@
 .tkr-tiles-6 .tkr-mtile.cfp-seed .val {
   color: var(--accent);
 }
+/* Projection tiles: same treatment, four across. Narrow screens still get the
+   two-up override from the 720px block below, which is declared later. */
+.tkr-tiles-4 { grid-template-columns: repeat(4, 1fr); }
 
 /* ── Upcoming Schedule ── */
 .tkr-sched-card {
@@ -695,41 +708,59 @@
 }
 
 /* ── Ratings table: shed columns as the viewport narrows ──────────────────────
-   Every column except TEAM has a fixed track (~620px of them), so on a narrow
+   Every column except TEAM has a fixed track (~862px of them), so on a narrow
    screen the fixed tracks hold their width and the 1fr TEAM column is the one
    crushed to nothing — the team name disappears while SOS and the sparkline
    survive. Dropping columns least-informative-first keeps RK / TEAM / ELO
    readable all the way down.
 
    Column order: 1 RK · 2 TEAM · 3 CONF · 4 W-L · 5 ELO · 6 Δ1W · 7 OFF ·
-                 8 DEF · 9 SOS · 10 10WK
+                 8 DEF · 9 SOS · 10 BID% · 11 CONF% · 12 NAT% · 13 PROJ W ·
+                 14 10WK
+   Projection columns shed in reverse order of interest: PROJ W is derivable
+   from the record, then the two secondary probabilities, leaving BID% as the
+   last projection number standing.
    Head and body rows share .tkr-grid, so one nth-child rule hides both. */
 
-@media (max-width: 1100px) {
+@media (max-width: 1280px) {
   /* 10WK sparkline — decorative next to the ELO number it summarizes */
-  .tkr-grid > div:nth-child(10) { display: none; }
-  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px; }
+  .tkr-grid > div:nth-child(14) { display: none; }
+  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px 58px 62px 58px 64px; }
 }
 
-@media (max-width: 900px) {
-  /* OFF / DEF / SOS — available on the team detail view */
+@media (max-width: 1100px) {
+  /* PROJ W — record plus games remaining says most of it */
+  .tkr-grid > div:nth-child(13) { display: none; }
+  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px 70px 70px 60px 58px 62px 58px; }
+}
+
+@media (max-width: 980px) {
+  /* OFF / DEF — available on the team detail view */
   .tkr-grid > div:nth-child(7),
-  .tkr-grid > div:nth-child(8),
-  .tkr-grid > div:nth-child(9) { display: none; }
-  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px; }
+  .tkr-grid > div:nth-child(8) { display: none; }
+  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px 60px 58px 62px 58px; }
+}
+
+@media (max-width: 860px) {
+  /* SOS, plus the secondary probabilities — BID% is the headline number */
+  .tkr-grid > div:nth-child(9),
+  .tkr-grid > div:nth-child(11),
+  .tkr-grid > div:nth-child(12) { display: none; }
+  .tkr-grid { grid-template-columns: 44px 1fr 88px 62px 78px 64px 58px; }
 }
 
 @media (max-width: 640px) {
   /* CONF and Δ1W — the conference stripe still carries the affiliation */
   .tkr-grid > div:nth-child(3),
   .tkr-grid > div:nth-child(6) { display: none; }
-  .tkr-grid { grid-template-columns: 40px 1fr 58px 72px; }
+  .tkr-grid { grid-template-columns: 40px 1fr 58px 72px 58px; }
   .tkr-grid > div { padding: 9px 8px; }
 }
 
 @media (max-width: 420px) {
   /* Down to the irreducible three: rank, team, rating */
-  .tkr-grid > div:nth-child(4) { display: none; }
+  .tkr-grid > div:nth-child(4),
+  .tkr-grid > div:nth-child(10) { display: none; }
   .tkr-grid { grid-template-columns: 34px 1fr 68px; }
   .tkr-grid > div { padding: 9px 6px; }
   .c-name { font-size: 12.5px; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,13 +46,15 @@
       </div>
 
       <!-- Game predictions (rendered by board.js; hidden until loaded) -->
-      <div class="tkr-preds-card hidden" id="tkr-preds">
-        <div class="tkr-preds-head">
-          <h2 class="tkr-preds-title">Game Predictions</h2>
-          <span class="tkr-preds-meta" id="tkr-preds-meta"></span>
-        </div>
+      <details class="tkr-preds-card hidden" id="tkr-preds" open>
+        <summary>
+          <div class="tkr-preds-head">
+            <h2 class="tkr-preds-title">Game Predictions</h2>
+            <span class="tkr-preds-meta" id="tkr-preds-meta"></span>
+          </div>
+        </summary>
         <div id="tkr-preds-body"></div>
-      </div>
+      </details>
 
       <!-- Projected playoff bracket (rendered by board.js; hidden until loaded) -->
       <div class="tkr-bracket-card hidden" id="tkr-bracket">

--- a/frontend/js/board.js
+++ b/frontend/js/board.js
@@ -109,6 +109,10 @@
       '<div class="heat ta-r" data-kind="off" data-v="' + (off == null ? '' : off) + '">' + (off == null ? '—' : off) + '</div>' +
       '<div class="heat ta-r" data-kind="def" data-v="' + (def == null ? '' : def) + '">' + (def == null ? '—' : def) + '</div>' +
       '<div class="c-sos ta-r' + (sosWarn ? ' warn' : '') + '">' + (e.sos == null ? '—' : e.sos.toFixed(3)) + '</div>' +
+      '<div class="c-odds ta-r">' + fmtPct(e.bid_pct) + '</div>' +
+      '<div class="c-odds ta-r">' + fmtPct(e.conf_title_pct) + '</div>' +
+      '<div class="c-odds ta-r">' + fmtPct(e.title_pct) + '</div>' +
+      '<div class="c-projw ta-r">' + (e.proj_wins == null ? '—' : e.proj_wins.toFixed(1)) + '</div>' +
       '<div class="ta-c">' + sparkline(e.elo_history, d) + '</div>' +
     '</div>';
   }
@@ -117,7 +121,10 @@
     var head = '<div class="tkr-grid tkr-head">' +
       '<div>RK</div><div>TEAM</div><div>CONF</div><div class="ta-r">W-L</div>' +
       '<div class="ta-r" style="color:var(--accent)">ELO</div><div class="ta-r">Δ1W</div>' +
-      '<div class="ta-r">OFF</div><div class="ta-r">DEF</div><div class="ta-r">SOS</div><div class="ta-c">10WK</div></div>';
+      '<div class="ta-r">OFF</div><div class="ta-r">DEF</div><div class="ta-r">SOS</div>' +
+      '<div class="ta-r">BID%</div><div class="ta-r">CONF%</div>' +
+      '<div class="ta-r">NAT%</div><div class="ta-r">PROJ W</div>' +
+      '<div class="ta-c">10WK</div></div>';
     
     // Apply filters
     var filtered = ENTRIES;
@@ -285,6 +292,19 @@
       }
     }
 
+    // Monte Carlo projection tiles. The rankings payload carries these per team,
+    // so no lookup into PLAYOFF_DATA is needed. The row is dropped entirely when
+    // no simulation covers the week — four em-dash tiles say nothing.
+    var hasOdds = e.bid_pct != null || e.conf_title_pct != null ||
+      e.title_pct != null || e.proj_wins != null;
+    var oddsTiles = !hasOdds ? '' :
+      '<div class="tkr-tiles-6 tkr-tiles-4">' +
+        tile('PLAYOFF BID', fmtPct(e.bid_pct)) +
+        tile('CONF TITLE', fmtPct(e.conf_title_pct)) +
+        tile('NAT TITLE', fmtPct(e.title_pct)) +
+        tile('PROJ WINS', e.proj_wins == null ? '—' : e.proj_wins.toFixed(1)) +
+      '</div>';
+
     var badgeRow = '';
     if (e.rank) {
       badgeRow += '<span class="badge-rank">No. ' + e.rank + '</span>';
@@ -321,6 +341,8 @@
         tile('WIN%', winpct) +
         '<div class="tkr-mtile cfp-seed"><div class="lbl">CFP SEED</div><div class="val">' + cfpSeed + '</div><div class="sub" style="font-family:var(--font-mono);font-size:9.5px;color:var(--fg3);margin-top:4px;text-transform:uppercase;">' + cfpSub + '</div></div>' +
       '</div>' +
+
+      oddsTiles +
 
       '<div class="tkr-detail-grid">' +
         '<div>' +

--- a/src/api/routers/rankings.py
+++ b/src/api/routers/rankings.py
@@ -143,7 +143,17 @@ async def get_rankings(
                 def_by_team[tid] = def_by_team.get(tid, 0) + (pa or 0)
                 counts[tid] = counts.get(tid, 0) + 1
 
-    # Attach rank_change, elo_history, espn_id, off, def to each ranking entry
+    # Monte Carlo projection columns (BID% / CONF% / NAT% / PROJ W). One cached
+    # row, matched to the exact week being displayed — a week-8 simulation must
+    # never be shown beside week-3 rankings. The simulation is far too slow to
+    # run in-request, so a week with no cached row simply has no odds.
+    odds_by_team: dict = {}
+    if team_ids:
+        projection = load_cached_projection(db, season, week=target_week)
+        for t in (projection or {}).get("teams") or []:
+            odds_by_team[t["team_id"]] = t
+
+    # Attach rank_change, elo_history, espn_id, off, def, odds to each entry
     for entry in rankings:
         tid = entry["team_id"]
         current_rank = entry["rank"]
@@ -160,6 +170,12 @@ async def get_rankings(
         n = counts.get(tid, 0) if team_ids else 0
         entry["off"] = round(off_by_team.get(tid, 0) / n, 1) if n else None
         entry["def"] = round(def_by_team.get(tid, 0) / n, 1) if n else None
+
+        o = odds_by_team.get(tid)
+        entry["bid_pct"] = o["bid_pct"] if o else None
+        entry["conf_title_pct"] = o["conf_title_pct"] if o else None
+        entry["title_pct"] = o["title_pct"] if o else None
+        entry["proj_wins"] = o["proj_wins"] if o else None
 
     return {
         "week": current_week,

--- a/src/core/season_simulation.py
+++ b/src/core/season_simulation.py
@@ -378,6 +378,7 @@ def build_projection(
         return {
             "season": season, "field": [], "first_round": [], "quarterfinals": [],
             "semifinals": [], "final": None, "champion": None, "bubble": [],
+            "teams": [],
             "runs": 0, "method": "monte_carlo", "through_week": inputs.through_week,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         }
@@ -457,10 +458,27 @@ def build_projection(
         for s in consensus[:BUBBLE_SIZE]
     ]
 
+    # Every team's odds, not just the twelve in the field and thirteen on the
+    # bubble: the rankings board carries these four numbers on every ranked row,
+    # so the payload has to cover all of FBS. Keys are listed out rather than
+    # copied wholesale so the internal "_i" index cannot leak into the payload.
+    all_teams = [
+        {
+            "team_id": st["team_id"],
+            "name": st["team_name"],
+            "bid_pct": st["bid_pct"],
+            "conf_title_pct": st["conf_title_pct"],
+            "title_pct": st["title_pct"],
+            "proj_wins": st["proj_wins"],
+        }
+        for st in ranked_by_bid
+    ]
+
     return {
         "season": season,
         "field": seeded,
         "bubble": bubble,
+        "teams": all_teams,
         "runs": agg["runs"],
         "method": "monte_carlo",
         "through_week": inputs.through_week,

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -265,6 +265,15 @@ class RankingEntry(BaseModel):
         None, alias="def", description="Avg points allowed per game (DEF heat cell)"
     )
 
+    # Monte Carlo projection columns. Attached from the cached playoff_simulation
+    # row for this exact week; None when no simulation covers the week shown.
+    bid_pct: Optional[float] = Field(None, description="Playoff bid probability (0-100)")
+    conf_title_pct: Optional[float] = Field(
+        None, description="Conference title probability (0-100)"
+    )
+    title_pct: Optional[float] = Field(None, description="National title probability (0-100)")
+    proj_wins: Optional[float] = Field(None, description="Projected final regular-season wins")
+
 
 class RankingsResponse(BaseModel):
     """Response for rankings endpoint"""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,9 +6,11 @@ empty board no matter what ELO it set. ``seed_board`` inserts the season, the
 teams, and the matching week snapshot together.
 """
 
+import json
+
 import pytest
 
-from src.models.models import RankingHistory, Season
+from src.models.models import PlayoffSimulation, RankingHistory, Season
 
 
 @pytest.fixture
@@ -21,9 +23,15 @@ def seed_board(test_db):
 
     Ranks are assigned by ELO descending, matching what the ranking service
     would produce for a real week.
+
+    Pass ``odds={"Alabama": {"bid_pct": 62.5, ...}}`` to also cache a playoff
+    simulation for the same (year, week), keyed by team name because the ids
+    do not exist until the flush below. The rankings endpoint only reads a
+    simulation whose week matches the board's, so seeding both together is the
+    point.
     """
 
-    def _seed(*teams, year=2024, week=5):
+    def _seed(*teams, year=2024, week=5, odds=None):
         test_db.add(Season(year=year, current_week=week, is_active=True))
         test_db.add_all(teams)
         test_db.flush()  # assign team ids
@@ -42,6 +50,15 @@ def seed_board(test_db):
                     losses=team.losses,
                 )
             )
+
+        if odds:
+            payload = {"teams": [
+                dict(odds[t.name], team_id=t.id, name=t.name)
+                for t in teams if t.name in odds
+            ]}
+            test_db.add(PlayoffSimulation(
+                season=year, week=week, runs=10, payload=json.dumps(payload)
+            ))
 
         test_db.commit()
         return teams

--- a/tests/e2e/test_rankings_page.py
+++ b/tests/e2e/test_rankings_page.py
@@ -146,6 +146,44 @@ class TestRankingsTableDisplay:
         expect(rows.nth(1)).to_contain_text("Georgia")
         expect(rows.nth(2)).to_contain_text("Ohio State")
 
+    def test_projection_columns_render(self, browser_page, seed_board):
+        """Cached simulation -> endpoint -> schema -> grid, end to end.
+
+        The other tests in this file seed no simulation, so they already cover
+        the em-dash path; this is the one that proves a real number arrives.
+        """
+        # Arrange
+        page, base_url = browser_page
+        from src.models.models import ConferenceType, Team
+
+        alabama = Team(
+            name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0, wins=5, losses=0
+        )
+        seed_board(
+            alabama,
+            odds={
+                "Alabama": {
+                    "bid_pct": 62.5,
+                    "conf_title_pct": 21.4,
+                    "title_pct": 8.1,
+                    "proj_wins": 9.3,
+                }
+            },
+        )
+
+        # Act
+        page.goto(f"{base_url}/frontend/index.html")
+        page.wait_for_selector(".tkr-row", timeout=5000)
+
+        # Assert - the headers exist and the row carries the numbers.
+        # fmtPct rounds at or above 10% and keeps a decimal below it.
+        expect(page.locator(".tkr-head")).to_contain_text("BID%")
+        expect(page.locator(".tkr-head")).to_contain_text("PROJ W")
+        first_row = page.locator(".tkr-row").first
+        expect(first_row).to_contain_text("63%")
+        expect(first_row).to_contain_text("8.1%")
+        expect(first_row).to_contain_text("9.3")
+
     def test_conference_displayed(self, browser_page, seed_board):
         """Test that team conference is displayed"""
         # Arrange

--- a/tests/frontend/test_board_columns.js
+++ b/tests/frontend/test_board_columns.js
@@ -26,7 +26,7 @@ const css = fs.readFileSync(
 const GRIDS = [
   {
     selector: '.tkr-grid',
-    total: 10, // RK TEAM CONF W-L ELO Δ1W OFF DEF SOS 10WK
+    total: 14, // RK TEAM CONF W-L ELO Δ1W OFF DEF SOS BID% CONF% NAT% PROJ W 10WK
     mustKeep: { 1: 'RK', 2: 'TEAM', 5: 'ELO' },
     narrowestVisible: 3,
   },

--- a/tests/frontend/test_board_row_cells.js
+++ b/tests/frontend/test_board_row_cells.js
@@ -1,0 +1,100 @@
+// Self-check for the ratings board's row and header cell counts.
+//   node tests/frontend/test_board_row_cells.js
+//
+// The head and the body rows share one .tkr-grid template, so a cell added to
+// rowHTML without a matching header cell (or the reverse) silently shifts every
+// column after it — ELO printed under the SOS heading, and so on. CSS cannot
+// catch that; the grid self-check next door only compares declared tracks to
+// visible ones. This compares the two markup strings to each other.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '../../frontend/js/board.js'), 'utf8'
+);
+
+/** Pull a top-level `function name(...) { ... }` block out of the source. */
+function extract(name) {
+  const start = src.indexOf('function ' + name + '(');
+  assert.notStrictEqual(start, -1, 'missing function ' + name);
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('unbalanced braces in ' + name);
+}
+
+// The board helpers a row leans on, stubbed down to what affects cell count.
+const preamble = `
+  var esc = function (s) { return String(s); };
+  var fmtElo = function (v) { return String(Math.round(v)); };
+  var trendClass = function () { return 'trend-flat'; };
+  var deltaText = function () { return '—'; };
+  var stripeOf = function () { return '#123456'; };
+  var logoImgFor = function () { return null; };
+  var sparkline = function () { return '<svg class="tkr-spark"></svg>'; };
+  var TeamVisuals = { confLabel: function (c) { return c || ''; } };
+`;
+
+const { rowHTML, fmtPct } = new Function(
+  preamble + extract('fmtPct') + extract('rowHTML') +
+  'return { rowHTML: rowHTML, fmtPct: fmtPct };'
+)();
+
+// The header lives inside renderGrid as a string literal; read it from source
+// rather than running renderGrid, which touches the DOM and module state.
+const headStart = src.indexOf("'<div class=\"tkr-grid tkr-head\">'");
+assert.notStrictEqual(headStart, -1, 'could not find the .tkr-head markup');
+const headSrc = src.slice(headStart, src.indexOf('</div>\';', headStart));
+
+const EXPECTED = 14; // keep in step with tests/frontend/test_board_columns.js
+
+function countDivs(s) {
+  return (s.match(/<div/g) || []).length;
+}
+
+const entry = {
+  team_id: 7, rank: 3, team_name: 'Ohio State', conference: 'P5',
+  conference_name: 'Big Ten', wins: 4, losses: 1, elo_rating: 1838.5,
+  rank_change: 2, sos: 0.601, off: 34.2, def: 15.8, elo_history: [1, 2, 3],
+  bid_pct: 50.8, conf_title_pct: 18.8, title_pct: 7.4, proj_wins: 8.5,
+};
+
+// ── Body row: the wrapper plus one div per column ──
+const row = rowHTML(entry);
+assert.strictEqual(
+  countDivs(row), EXPECTED + 1,
+  'rowHTML should emit ' + EXPECTED + ' cells inside one wrapper div'
+);
+
+// ── Header: one div per column, wrapper included ──
+assert.strictEqual(
+  countDivs(headSrc), EXPECTED + 1,
+  'the .tkr-head markup must carry the same number of cells as a row'
+);
+
+// ── The projection cells actually render their values ──
+// fmtPct keeps a decimal below 10% and rounds above it, so 50.8 -> "51%".
+['51%', '19%', '7.4%', '8.5'].forEach(function (v) {
+  assert.ok(row.indexOf(v) !== -1, 'row should contain ' + v);
+});
+
+// ── A team with no simulation gets em dashes, never "undefined" ──
+const bare = Object.assign({}, entry, {
+  bid_pct: null, conf_title_pct: null, title_pct: null, proj_wins: null,
+});
+const bareRow = rowHTML(bare);
+assert.strictEqual(
+  countDivs(bareRow), EXPECTED + 1, 'the empty state must not drop cells'
+);
+assert.strictEqual(
+  (bareRow.match(/—/g) || []).length >= 4, true,
+  'four projection cells should read as em dashes'
+);
+assert.ok(!/undefined/.test(bareRow), 'missing odds must not print "undefined"');
+assert.ok(!/null/.test(bareRow), 'missing odds must not print "null"');
+
+console.log('board row cell self-check passed (' + EXPECTED + ' columns)');

--- a/tests/integration/test_rankings_odds_api.py
+++ b/tests/integration/test_rankings_odds_api.py
@@ -1,0 +1,128 @@
+"""Integration tests for the Monte Carlo projection columns on /api/rankings.
+
+The four numbers (BID% / CONF% / NAT% / PROJ W) come from the cached
+``playoff_simulation`` row for the *exact* week being displayed. These tests
+insert that row directly rather than running a simulation, which keeps them
+fast and lets them cover payload shapes a real simulation never produces —
+notably a row written before the ``teams`` key existed.
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.models.models import (
+    ConferenceType,
+    PlayoffSimulation,
+    RankingHistory,
+    Season,
+    Team,
+)
+
+ODDS = {"bid_pct": 62.5, "conf_title_pct": 21.4, "title_pct": 8.1, "proj_wins": 9.3}
+
+
+def seed(db: Session, week: int = 5, season: int = 2024):
+    """Two ranked teams in a season sitting at ``week``."""
+    db.add(Season(year=season, current_week=week, is_active=True))
+    teams = [
+        Team(name="Alabama", conference=ConferenceType.POWER_5, elo_rating=1850.0),
+        Team(name="Georgia", conference=ConferenceType.POWER_5, elo_rating=1840.0),
+    ]
+    db.add_all(teams)
+    db.flush()
+    for rank, t in enumerate(teams, start=1):
+        db.add(RankingHistory(
+            team_id=t.id, season=season, week=week, rank=rank,
+            elo_rating=t.elo_rating, wins=4, losses=1,
+        ))
+    db.commit()
+    return teams
+
+
+def store(db: Session, payload: dict, week: int = 5, season: int = 2024):
+    db.add(PlayoffSimulation(
+        season=season, week=week, runs=10, payload=json.dumps(payload)
+    ))
+    db.commit()
+
+
+def entries(response):
+    return {e["team_name"]: e for e in response.json()["rankings"]}
+
+
+@pytest.mark.integration
+class TestRankingsProjectionColumns:
+    def test_odds_attached_for_matching_week(self, test_client: TestClient, test_db: Session):
+        teams = seed(test_db)
+        store(test_db, {"teams": [dict(ODDS, team_id=teams[0].id, name="Alabama")]})
+
+        rows = entries(test_client.get("/api/rankings"))
+
+        for key, value in ODDS.items():
+            assert rows["Alabama"][key] == value
+
+    def test_fields_present_and_null_without_a_simulation(
+        self, test_client: TestClient, test_db: Session
+    ):
+        """The keys must survive the response model even when there is no data.
+
+        RankingEntry is a plain pydantic model, so a field it does not declare is
+        silently dropped. Asserting presence is what catches that.
+        """
+        seed(test_db)
+
+        rows = entries(test_client.get("/api/rankings"))
+
+        for key in ODDS:
+            assert key in rows["Alabama"]
+            assert rows["Alabama"][key] is None
+
+    def test_simulation_from_another_week_is_not_shown(
+        self, test_client: TestClient, test_db: Session
+    ):
+        """A week-8 simulation beside week-3 rankings would be quietly wrong."""
+        teams = seed(test_db, week=8)
+        # The same teams also have a week-3 snapshot, so week 3 renders a board.
+        for rank, t in enumerate(teams, start=1):
+            test_db.add(RankingHistory(
+                team_id=t.id, season=2024, week=3, rank=rank,
+                elo_rating=t.elo_rating, wins=2, losses=1,
+            ))
+        test_db.commit()
+        store(test_db, {"teams": [dict(ODDS, team_id=teams[0].id, name="Alabama")]}, week=8)
+
+        rows = entries(test_client.get("/api/rankings?week=3"))
+
+        assert set(rows) == {"Alabama", "Georgia"}  # the board did render
+        assert rows["Alabama"]["bid_pct"] is None
+        assert entries(test_client.get("/api/rankings?week=8"))["Alabama"]["bid_pct"] == 62.5
+
+    def test_team_missing_from_payload_gets_nulls(
+        self, test_client: TestClient, test_db: Session
+    ):
+        teams = seed(test_db)
+        store(test_db, {"teams": [dict(ODDS, team_id=teams[0].id, name="Alabama")]})
+
+        rows = entries(test_client.get("/api/rankings"))
+
+        assert rows["Alabama"]["bid_pct"] == ODDS["bid_pct"]
+        assert rows["Georgia"]["bid_pct"] is None
+        assert rows["Georgia"]["proj_wins"] is None
+
+    def test_payload_without_teams_key_still_serves(
+        self, test_client: TestClient, test_db: Session
+    ):
+        """Rows cached before this feature shipped have field/bubble only."""
+        teams = seed(test_db)
+        store(test_db, {
+            "field": [dict(ODDS, team_id=teams[0].id, name="Alabama", seed=1)],
+            "bubble": [],
+        })
+
+        response = test_client.get("/api/rankings")
+
+        assert response.status_code == 200
+        assert entries(response)["Alabama"]["bid_pct"] is None

--- a/tests/unit/test_season_simulation.py
+++ b/tests/unit/test_season_simulation.py
@@ -359,6 +359,71 @@ class TestBuildProjection:
         assert len(projection["semifinals"]) == 2
         assert projection["champion"]["team_id"] in field_ids
 
+    def test_projection_covers_every_team(self, db_session):
+        """The board carries odds on every ranked row, so the payload must too."""
+        from src.models.models import ConferenceType, Season, Team
+
+        db_session.add(Season(year=2034, current_week=4, is_active=False))
+        for conf, tier in CONFERENCES.items():
+            for j in range(TEAMS_PER_CONF):
+                db_session.add(Team(
+                    name=f"{conf} {j}",
+                    conference=(
+                        ConferenceType.POWER_5 if tier == "P5" else ConferenceType.GROUP_5
+                    ),
+                    conference_name=conf,
+                    is_fcs=False,
+                    elo_rating=1500.0 + (TEAMS_PER_CONF - j) * 30,
+                ))
+        db_session.commit()
+        n_teams = len(CONFERENCES) * TEAMS_PER_CONF
+
+        projection = ss.build_projection(db_session, 2034, runs=30, seed=7)
+        teams = projection["teams"]
+
+        ids = [t["team_id"] for t in teams]
+        assert len(teams) == n_teams
+        assert len(set(ids)) == n_teams
+
+        # A strict superset of what the bracket panel already publishes.
+        shown = {t["team_id"] for t in projection["field"]}
+        shown |= {t["team_id"] for t in projection["bubble"]}
+        assert shown < set(ids)
+
+        for t in teams:
+            # The internal loop index and the rating swap must not leak out.
+            assert set(t) == {
+                "team_id", "name", "bid_pct", "conf_title_pct", "title_pct", "proj_wins"
+            }
+            assert 0.0 <= t["bid_pct"] <= 100.0
+            assert 0.0 <= t["conf_title_pct"] <= 100.0
+            assert 0.0 <= t["title_pct"] <= 100.0
+            assert t["proj_wins"] >= 0.0
+
+        # One source of truth: a team in both lists reports the same odds.
+        by_id = {t["team_id"]: t for t in teams}
+        for f in projection["field"]:
+            assert by_id[f["team_id"]]["bid_pct"] == f["bid_pct"]
+            assert by_id[f["team_id"]]["proj_wins"] == f["proj_wins"]
+
+    def test_short_field_payload_has_teams_key(self, db_session):
+        """Too few teams to simulate still returns the key, just empty."""
+        from src.models.models import ConferenceType, Season, Team
+
+        db_session.add(Season(year=2035, current_week=1, is_active=False))
+        for j in range(FIELD_SIZE - 1):
+            db_session.add(Team(
+                name=f"Tiny {j}",
+                conference=ConferenceType.POWER_5,
+                conference_name="Tiny",
+                is_fcs=False,
+                elo_rating=1500.0,
+            ))
+        db_session.commit()
+
+        projection = ss.build_projection(db_session, 2035, runs=5, seed=1)
+        assert projection["teams"] == []
+
     def test_cache_round_trip(self, db_session):
         from src.models.models import ConferenceType, Season, Team
 
@@ -384,6 +449,7 @@ class TestBuildProjection:
         assert cached["runs"] == stored["runs"] == 20
         assert cached["through_week"] == 3
         assert [t["team_id"] for t in cached["field"]] == [t["team_id"] for t in stored["field"]]
+        assert cached["teams"] == stored["teams"]
 
     def test_refresh_replaces_rather_than_duplicates(self, db_session):
         from src.models.models import ConferenceType, PlayoffSimulation, Season, Team


### PR DESCRIPTION
## What

The Monte Carlo season simulation already computed a playoff-bid, conference-title and national-title probability plus a projected win total for every one of the 135 FBS teams — and then discarded everything outside the twelve-team field and thirteen-team bubble when it serialized. Until now those numbers reached a human only through the CLI table in `scripts/simulate_season.py`.

They are now four columns on the rankings board, four tiles on the team detail panel, and part of the `/api/rankings` payload.

Also makes the Game Predictions card on the homepage collapsible.

## How

**Server-side, on the rankings endpoint** — not a client-side join. Two reasons: the board fills from `/api/rankings` and renders immediately while `PLAYOFF_DATA` arrives later with no re-render, and `/api/playoff-projection` loads the most recently simulated week regardless of which week the board is showing. A week-8 simulation printed beside week-3 rankings is quietly wrong in a way nobody would notice. `/api/rankings` is the only place that knows the target week.

`build_projection` publishes a `teams` list covering every team. Keys are listed explicitly rather than copied, so the internal `_i` index and the temporary `elo_rating`/`mean_rating` swap cannot leak. `field`, `bubble` and the bracket keys are untouched, so `renderOdds`, the CFP SEED tile and `renderCFPPath` keep working unchanged. Cached payload goes 8.4KB → 23.3KB.

Declaring the four fields on `RankingEntry` is load-bearing, not bookkeeping: `RankingEntry` has no `model_config`, so pydantic silently drops keys the response model does not declare.

No migration — `playoff_simulation.payload` is already `Text`.

## Layout

The board goes from ten columns to fourteen, and the shedding ladder is rewritten around them (every rule is a positional `nth-child`, so all indices shifted). Priority: decoration first (the sparkline restates ELO), then the derivable (PROJ W is record plus games left), then what the detail view also carries (OFF/DEF/SOS), then the secondary probabilities — leaving BID% as the last projection number standing.

| max-width | hides | tracks left |
|---|---|---|
| 1280px | 10WK | 13 |
| 1100px | PROJ W | 12 |
| 980px | OFF, DEF | 10 |
| 860px | SOS, CONF%, NAT% | 7 |
| 640px | CONF, Δ1W | 5 |
| 420px | W-L, BID% | 3 |

`.tkr-wrap` is not widened — it is shared by six pages.

Weeks with no cached simulation render em dashes and keep the columns in place. The detail panel drops its tile row entirely in that case; four em-dash tiles say nothing.

The predictions card is a `<details>` with the existing header as its `<summary>`, so the browser does the collapsing and no JavaScript changed. It defaults open — no change to what loads today.

## Verification

- 864 non-E2E tests (was 857) and 47 E2E (was 46), all passing
- All six node self-checks pass — and `tests/frontend/test_board_columns.js` failed exactly as designed when the grid changed, which is what it is for
- Against the real local database: a payload cached before this change → all four fields `null`, HTTP 200, no `KeyError`; after re-simulating → `Georgia 60.9 / 19.9 / 7.5 / 8.2`; `?week=0` → `null`
- Rendered at 1400 / 1200 / 1000 / 900 / 700 / 400px — header and body cells shed together, 400px still lands on RK · TEAM · ELO

New tests: `teams` coverage and no-leakage in the unit suite; five endpoint cases including a legacy payload with only `field`/`bubble`; a row/header cell-count check that CSS cannot provide; one E2E test through cache → endpoint → schema → grid.

`ad0c525` also wires the six frontend self-checks into CI, where they had never run.

## Deploy note

No migration, but there **is** a data step. Production's one cached row (season 2026, week 1) predates this change and has no `teams` key, so the columns render em dashes until `python3 scripts/simulate_season.py --season 2026 --runs 10000` is re-run on the server. Degraded, not broken. Every subsequent weekly import refreshes it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)