### PR TITLE
Trim the prediction table and add Umami analytics

### DIFF
--- a/frontend/css/components/board.css
+++ b/frontend/css/components/board.css
@@ -810,3 +810,9 @@
   .tkr-sched-grid > div:nth-child(5) { display: none; }
   .tkr-sched-grid { grid-template-columns: 32px 20px 1fr 48px; gap: 6px; }
 }
+
+.tkr-preds-more { display: block; width: 100%; margin-top: 8px; padding: 10px; cursor: pointer;
+  background: none; border: 1px solid var(--line); border-radius: 8px; color: var(--fg2);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600; letter-spacing: 0.05em;
+  text-transform: uppercase; }
+.tkr-preds-more:hover { color: var(--fg); border-color: var(--fg3); }

--- a/frontend/js/board.js
+++ b/frontend/js/board.js
@@ -786,6 +786,10 @@
     '</div>';
   }
 
+  // Rows shown before the "show more" cut. A full week runs 60+ games, which
+  // buries the bracket below it.
+  var PRED_VISIBLE = 15;
+
   function renderPredictions(list) {
     var card = document.getElementById('tkr-preds');
     if (!card) return;
@@ -793,7 +797,23 @@
     set('tkr-preds-meta', 'WK' + list[0].week + ' · ' + list.length + ' GAMES');
     var head = '<div class="tkr-pgrid tkr-phead"><div>MATCHUP</div><div>PROJ</div>' +
       '<div>WIN PROB</div><div>SPREAD</div><div>CONF</div></div>';
-    document.getElementById('tkr-preds-body').innerHTML = head + list.map(predRow).join('');
+    var rows = list.map(predRow);
+    var body = head + rows.slice(0, PRED_VISIBLE).join('');
+    var rest = rows.slice(PRED_VISIBLE);
+    if (rest.length) {
+      body += '<div id="tkr-preds-rest" class="hidden">' + rest.join('') + '</div>' +
+        '<button type="button" class="tkr-preds-more" id="tkr-preds-more">' +
+        'Show ' + rest.length + ' more</button>';
+    }
+    document.getElementById('tkr-preds-body').innerHTML = body;
+    var more = document.getElementById('tkr-preds-more');
+    if (more) {
+      more.addEventListener('click', function () {
+        var restEl = document.getElementById('tkr-preds-rest');
+        var hidden = restEl.classList.toggle('hidden');
+        more.textContent = hidden ? 'Show ' + rest.length + ' more' : 'Show fewer';
+      });
+    }
     card.classList.remove('hidden');
   }
 

--- a/frontend/js/layout.js
+++ b/frontend/js/layout.js
@@ -14,6 +14,18 @@
   var showSeason = cfg.season !== 'false';
   var isBoard = currentPage === 'index.html' || currentPage === '';
 
+  // Umami analytics, injected here rather than pasted into eight <head> blocks.
+  // data-domains keeps localhost and any preview host out of the numbers, and
+  // admin.html is skipped so dashboard visits do not count as traffic.
+  if (currentPage !== 'admin.html') {
+    var umami = document.createElement('script');
+    umami.defer = true;
+    umami.src = 'https://analytics.bdailey.com/script.js';
+    umami.dataset.websiteId = '130cfa1d-3da5-4015-b68a-a927951aeaf8';
+    umami.dataset.domains = 'cfb.bdailey.com';
+    document.head.appendChild(umami);
+  }
+
   var links = [
     ['index.html', 'Rankings'],
     ['games.html', 'Games'],

--- a/tests/frontend/test_layout_analytics.js
+++ b/tests/frontend/test_layout_analytics.js
@@ -1,0 +1,82 @@
+// Self-check for the Umami tag layout.js injects.
+//   node tests/frontend/test_layout_analytics.js
+//
+// The tracker is created in script rather than pasted into eight <head> blocks,
+// so nothing in the HTML shows whether it is still wired up. This runs layout.js
+// against a stub document and inspects the <script> it appends: every public
+// page gets one, admin.html does not, and the website id stays intact.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '../../frontend/js/layout.js'), 'utf8'
+);
+
+const WEBSITE_ID = '130cfa1d-3da5-4015-b68a-a927951aeaf8';
+const SCRIPT_SRC = 'https://analytics.bdailey.com/script.js';
+
+/** Run layout.js for one page path; return the scripts it appended to <head>. */
+function inject(pathname) {
+  const appended = [];
+  const stubEl = () => ({
+    dataset: {}, innerHTML: '', className: '', style: {},
+    classList: { add() {}, remove() {}, contains: () => false, toggle: () => false },
+    appendChild() {}, insertBefore() {}, addEventListener() {},
+    insertAdjacentHTML() {},
+    setAttribute() {}, querySelector: () => null, querySelectorAll: () => [],
+  });
+  global.location = { pathname: pathname, search: '', href: 'https://x/' + pathname };
+  global.document = {
+    // layout.js reads config off its own <script> tag.
+    currentScript: Object.assign(stubEl(), { dataset: {} }),
+    head: { appendChild: (el) => appended.push(el) },
+    body: stubEl(),
+    documentElement: stubEl(),
+    createElement: () => stubEl(),
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    addEventListener() {},
+  };
+  global.window = { addEventListener() {}, matchMedia: () => ({ matches: false, addEventListener() {} }) };
+  try {
+    new Function(src)();
+  } catch (err) {
+    // The chrome markup needs more DOM than this stub provides. The tracker is
+    // injected before any of that, so a later failure does not hide a miss.
+    if (appended.length === 0) throw err;
+  }
+  return appended;
+}
+
+// ── Every public page gets exactly one tracker, correctly configured ──
+['/index.html', '/', '/games.html', '/team.html', '/simulator.html'].forEach(function (p) {
+  const scripts = inject(p);
+  assert.strictEqual(scripts.length, 1, p + ' should inject exactly one script');
+  const tag = scripts[0];
+  assert.strictEqual(tag.src, SCRIPT_SRC, p + ' should point at the Umami host');
+  assert.strictEqual(tag.dataset.websiteId, WEBSITE_ID, p + ' should carry the website id');
+  assert.strictEqual(tag.defer, true, p + ' should load the tracker deferred');
+  assert.strictEqual(
+    tag.dataset.domains, 'cfb.bdailey.com',
+    p + ' should restrict counting to the production host'
+  );
+});
+
+// ── The admin page stays out of the numbers ──
+assert.strictEqual(
+  inject('/admin.html').length, 0, 'admin.html must not load the tracker'
+);
+
+// ── The id is a real UUID, not a leftover placeholder ──
+assert.ok(
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(WEBSITE_ID),
+  'the website id should be a UUID'
+);
+assert.ok(
+  src.indexOf(WEBSITE_ID) !== -1, 'layout.js should still hold the website id'
+);
+
+console.log('layout analytics self-check passed');

--- a/tests/frontend/test_preds_truncation.js
+++ b/tests/frontend/test_preds_truncation.js
@@ -1,0 +1,133 @@
+// Self-check for the game-prediction table's "show more" cut.
+//   node tests/frontend/test_preds_truncation.js
+//
+// A full week is 60+ games, which buried the projected bracket underneath it.
+// renderPredictions now prints the first PRED_VISIBLE rows and parks the rest
+// behind a button. This checks the split arithmetic and the toggle, which no
+// CSS check can see.
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+  path.join(__dirname, '../../frontend/js/board.js'), 'utf8'
+);
+
+/** Pull a top-level `function name(...) { ... }` block out of the source. */
+function extract(name) {
+  const start = src.indexOf('function ' + name + '(');
+  assert.notStrictEqual(start, -1, 'missing function ' + name);
+  let depth = 0;
+  for (let i = src.indexOf('{', start); i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error('unbalanced braces in ' + name);
+}
+
+const visibleMatch = src.match(/var PRED_VISIBLE = (\d+);/);
+assert.ok(visibleMatch, 'PRED_VISIBLE should be declared in board.js');
+const PRED_VISIBLE = Number(visibleMatch[1]);
+assert.ok(
+  PRED_VISIBLE >= 10 && PRED_VISIBLE <= 25,
+  'PRED_VISIBLE should sit in the 10–25 range the board was designed for'
+);
+
+// ── Minimal DOM: only the four ids renderPredictions reaches for ──
+function makeEl() {
+  const classes = new Set();
+  return {
+    innerHTML: '', textContent: '', handler: null,
+    classList: {
+      add: (c) => classes.add(c),
+      remove: (c) => classes.delete(c),
+      contains: (c) => classes.has(c),
+      toggle: (c) => (classes.has(c) ? (classes.delete(c), false) : (classes.add(c), true)),
+    },
+    addEventListener: function (_, fn) { this.handler = fn; },
+    click: function () { this.handler(); },
+  };
+}
+
+const els = {
+  'tkr-preds': makeEl(),
+  'tkr-preds-meta': makeEl(),
+  'tkr-preds-body': makeEl(),
+  'tkr-preds-rest': makeEl(),
+  'tkr-preds-more': makeEl(),
+};
+// The rest/more elements only exist once the body markup declares them.
+global.document = {
+  getElementById: (id) => {
+    if ((id === 'tkr-preds-rest' || id === 'tkr-preds-more') &&
+        els['tkr-preds-body'].innerHTML.indexOf('id="' + id + '"') === -1) return null;
+    return els[id] || null;
+  },
+};
+els['tkr-preds-rest'].classList.add('hidden');
+
+const preamble = `
+  var esc = function (s) { return String(s); };
+  var abbrName = function (n) { return String(n).slice(0, 3).toUpperCase(); };
+  var stripeName = function () { return '#123456'; };
+  var pairColor = function () { return '#654321'; };
+  var CONF = { High: 'HIGH' };
+  var set = function (id, txt) { document.getElementById(id).textContent = txt; };
+  var PRED_VISIBLE = ${PRED_VISIBLE};
+`;
+
+const { renderPredictions } = new Function(
+  preamble + extract('predRow') + extract('renderPredictions') +
+  'return { renderPredictions: renderPredictions };'
+)();
+
+function games(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    game_id: i, week: 4, away_team: 'Away' + i, home_team: 'Home' + i,
+    away_win_probability: 40, home_win_probability: 60,
+    predicted_away_score: 21, predicted_home_score: 28,
+    predicted_winner: 'Home' + i, is_neutral_site: false, confidence: 'High',
+  }));
+}
+
+const countRows = (s) => (s.match(/tkr-prow/g) || []).length;
+
+// ── Short list: every row visible, no button ──
+renderPredictions(games(PRED_VISIBLE));
+let body = els['tkr-preds-body'].innerHTML;
+assert.strictEqual(countRows(body), PRED_VISIBLE, 'a short list should render in full');
+assert.ok(body.indexOf('tkr-preds-more') === -1, 'a short list needs no expand button');
+assert.ok(!els['tkr-preds'].classList.contains('hidden'), 'the card should be shown');
+
+// ── Long list: every row still emitted, the overflow parked and hidden ──
+const total = PRED_VISIBLE + 47;
+renderPredictions(games(total));
+body = els['tkr-preds-body'].innerHTML;
+assert.strictEqual(countRows(body), total, 'no game may be dropped, only hidden');
+const before = body.slice(0, body.indexOf('id="tkr-preds-rest"'));
+assert.strictEqual(
+  countRows(before), PRED_VISIBLE,
+  'exactly PRED_VISIBLE rows belong outside the collapsed block'
+);
+assert.ok(
+  body.indexOf('Show ' + (total - PRED_VISIBLE) + ' more') !== -1,
+  'the button should name the remaining game count'
+);
+
+// ── The button toggles both ways ──
+const more = document.getElementById('tkr-preds-more');
+const rest = document.getElementById('tkr-preds-rest');
+assert.ok(rest.classList.contains('hidden'), 'the overflow starts collapsed');
+more.click();
+assert.ok(!rest.classList.contains('hidden'), 'clicking should reveal the overflow');
+assert.strictEqual(more.textContent, 'Show fewer');
+more.click();
+assert.ok(rest.classList.contains('hidden'), 'clicking again should re-collapse');
+assert.strictEqual(more.textContent, 'Show ' + (total - PRED_VISIBLE) + ' more');
+
+// ── An empty week hides the card entirely ──
+renderPredictions([]);
+assert.ok(els['tkr-preds'].classList.contains('hidden'), 'no games means no card');
+
+console.log('prediction table truncation self-check passed (' + PRED_VISIBLE + ' visible)');


### PR DESCRIPTION
Two unrelated front-end changes that happened to land on the same branch.

## Prediction table cut-off

A full week runs 60-plus games and the table printed every one of them, which
pushed the projected playoff bracket off the bottom of the screen unless you
collapsed the whole predictions card first. The first 15 rows now render as
before and the rest go into a hidden div behind a button that names how many
are left. Nothing is dropped from the markup, only hidden, so the card's
existing `<details>` toggle keeps working the way it did.

## Umami analytics

`cfb.bdailey.com` now reports to the existing `analytics.bdailey.com` instance.
The tag is created in `layout.js` — the one file every page already loads —
rather than pasted into eight `<head>` blocks, so the host and the website id
live in a single place. `data-domains` pins counting to the production hostname
so local development stays out of the numbers, and `admin.html` is skipped so
dashboard visits are not counted as traffic.

## Tests

Two new node self-checks under `tests/frontend/`, picked up by the existing
glob in the test job:

- `test_preds_truncation.js` — no game is dropped, the split lands at
  `PRED_VISIBLE`, the button toggles both ways, an empty week hides the card.
- `test_layout_analytics.js` — every public page injects exactly one correctly
  configured tracker, `admin.html` injects none.

Both were mutation-checked, and the full front-end suite (8 checks) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)