### PR TITLE
Projection columns, and the season opener on the board

### DIFF
--- a/frontend/js/countdown.js
+++ b/frontend/js/countdown.js
@@ -10,9 +10,9 @@
 
   var base = (typeof API_BASE_URL !== 'undefined') ? API_BASE_URL : '/api';
 
-  // game_date is stored UTC-naive and serialized without an offset
-  // ("2026-08-29T16:00:00"). JS parses offset-less date-time strings as LOCAL
-  // time, which would skew the countdown by the viewer's UTC offset.
+  // The API stamps game_date with a UTC offset, but older cached responses (and
+  // the raw sqlite " "-separated form) can arrive bare. JS reads an offset-less
+  // date-time as LOCAL, which skews the countdown by the viewer's UTC offset.
   function parseUtc(s) {
     if (!s) return null;
     var iso = /(Z|[+-]\d{2}:?\d{2})$/.test(s) ? s : s + 'Z';

--- a/scripts/start_new_season.py
+++ b/scripts/start_new_season.py
@@ -90,11 +90,14 @@ def create_new_season(db, season_year: int, dry_run: bool = True):
         Season object (or None in dry run)
     """
     print(f"\nCreating {season_year} season:")
-    print(f"  - Starting week: 1")
+    # current_week tracks the last week we *processed*, so a season with no
+    # results yet is week 0. Seeding 1 made the site claim week 1 was already
+    # in the books and pushed "next week" predictions past the opener.
+    print(f"  - Starting week: 0 (preseason)")
     print(f"  - Active: True")
 
     if not dry_run:
-        new_season = Season(year=season_year, current_week=1, is_active=True)
+        new_season = Season(year=season_year, current_week=0, is_active=True)
         db.add(new_season)
         db.commit()
         print(f"  ✅ Created season {season_year}")

--- a/src/api/routers/predictions.py
+++ b/src/api/routers/predictions.py
@@ -14,6 +14,7 @@ from src.core.ranking_service import (
     generate_predictions,
     get_overall_prediction_accuracy,
     get_team_prediction_accuracy,
+    next_slate_window,
 )
 from src.models import schemas
 from src.models.database import get_db
@@ -62,10 +63,19 @@ async def get_predictions(
         # Apply filters
         if week is not None:
             query = query.filter(Game.week == week)
+        elif next_week:
+            # Narrow to the next slate by date, not by week number — a CFB week
+            # can straddle a nine-day span (see next_slate_window).
+            window = next_slate_window(db, season)
+            if window:
+                slate_week, start, end = window
+                query = query.filter(
+                    Game.week == slate_week, Game.game_date >= start, Game.game_date < end
+                )
         if team_id:
             query = query.filter(or_(Game.home_team_id == team_id, Game.away_team_id == team_id))
 
-        stored_predictions = query.all()
+        stored_predictions = query.order_by(Game.game_date, Game.id).all()
 
         # If we have stored predictions, return those
         if stored_predictions:
@@ -103,6 +113,7 @@ async def get_predictions(
                     "confidence": confidence,
                     "week": game.week,
                     "season": game.season,
+                    "game_date": schemas.iso_utc(game.game_date),
                 })
             return result
 
@@ -208,7 +219,7 @@ async def get_historical_predictions(
                 game_id=game.id,
                 week=game.week,
                 season=game.season,
-                game_date=game.game_date.isoformat() if game.game_date else None,
+                game_date=schemas.iso_utc(game.game_date),
                 is_neutral_site=game.is_neutral_site,
                 home_team_id=home_team.id,
                 home_team=home_team.name,

--- a/src/api/routers/rankings.py
+++ b/src/api/routers/rankings.py
@@ -294,7 +294,7 @@ async def get_postseason(season: int, db: Session = Depends(get_db)):
             "home_score": g.home_score,
             "away_score": g.away_score,
             "is_neutral_site": g.is_neutral_site,
-            "game_date": g.game_date.isoformat() if g.game_date else None,
+            "game_date": schemas.iso_utc(g.game_date),
             "winner_team_id": g.home_team_id if home_won else g.away_team_id,
             "winner_name": home.name if home_won else away.name,
             "loser_name": away.name if home_won else home.name,

--- a/src/api/routers/teams.py
+++ b/src/api/routers/teams.py
@@ -306,7 +306,7 @@ async def get_team_schedule(team_id: int, season: int, db: Session = Depends(get
             {
                 "game_id": game.id,
                 "week": game.week,
-                "game_date": game.game_date.isoformat() if game.game_date else None,  # EPIC-GAME-DATE-SORTING: Include game date
+                "game_date": schemas.iso_utc(game.game_date),  # EPIC-GAME-DATE-SORTING: Include game date
                 "opponent_id": opponent.id,
                 "opponent_name": opponent.name,
                 "opponent_conference": opponent.conference.value if opponent.conference else None,

--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -36,7 +36,7 @@ import logging
 import math
 import os
 import statistics
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import or_
@@ -1181,6 +1181,69 @@ class RankingService:
 # Prediction Functions (standalone, not part of RankingService class)
 
 
+# A CFB week normally runs 5 days or less, even with midweek MACtion pulling
+# Tuesday and Wednesday games in ahead of Saturday. Only a genuinely split week
+# — 2026's week 1, which plays 8 games on Aug 29 and the other 91 over Labor Day
+# weekend nine days later — opens a hole this big.
+SLATE_SPLIT_DAYS = 4
+
+
+def next_slate_window(
+    db: Session, season_year: int, today: Optional[date] = None
+) -> Optional[Tuple[int, datetime, datetime]]:
+    """Find the next slate of games as a date window rather than a week number.
+
+    Week numbers are usually a fine proxy for "what's on next", but not always:
+    CFBD's 2026 week 1 spans Aug 29 through Sep 7. Filtering by week alone puts
+    all 99 of those games on the board at once and keeps them there for a week
+    and a half.
+
+    So: walk the season's remaining weeks in order, split any week that has an
+    internal gap of SLATE_SPLIT_DAYS or more, and return the first resulting
+    slate that hasn't finished yet, as a (week, start, end) triple covering a
+    half-open date range.
+
+    Returns None when no unprocessed game carries a date, so callers can fall
+    back to week-number filtering.
+    """
+    rows = (
+        db.query(Game.week, Game.game_date)
+        .filter(
+            Game.season == season_year,
+            Game.is_processed == False,  # noqa: E712
+            Game.game_date.isnot(None),
+        )
+        .all()
+    )
+    if not rows:
+        return None
+
+    # Game datetimes are stored as naive UTC, so group on UTC days.
+    days_by_week: Dict[int, set] = {}
+    for week, when in rows:
+        days_by_week.setdefault(week, set()).add(when.date())
+    today = today or datetime.utcnow().date()
+
+    for week in sorted(days_by_week):
+        days = sorted(days_by_week[week])
+        slate = [days[0]]
+        for day in days[1:]:
+            if (day - slate[-1]).days < SLATE_SPLIT_DAYS:
+                slate.append(day)
+                continue
+            if slate[-1] >= today:
+                break
+            slate = [day]
+        if slate[-1] >= today:
+            return (
+                week,
+                datetime.combine(slate[0], time.min),
+                datetime.combine(slate[-1] + timedelta(days=1), time.min),
+            )
+
+    return None  # every remaining game is in the past
+
+
 def generate_predictions(
     db: Session,
     week: Optional[int] = None,
@@ -1210,13 +1273,20 @@ def generate_predictions(
 
     # Apply week filter
     if next_week:
-        # Get current week from Season model
         current_week = db.query(Season.current_week).filter(Season.year == season_year).scalar()
-
         if current_week is None:
             return []  # No active season
 
-        query = query.filter(Game.week == current_week + 1)
+        window = next_slate_window(db, season_year)
+        if window is None:
+            # Undated schedule (or nothing left to play) — fall back to the
+            # week after the last one we processed.
+            query = query.filter(Game.week == current_week + 1)
+        else:
+            slate_week, start, end = window
+            query = query.filter(
+                Game.week == slate_week, Game.game_date >= start, Game.game_date < end
+            )
     elif week is not None:
         query = query.filter(Game.week == week)
 

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -33,12 +33,27 @@ Note:
     at /docs endpoint. Keep descriptions clear and concise.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 from src.models.models import ConferenceType
+
+
+def iso_utc(dt: Optional[datetime]) -> Optional[str]:
+    """Serialize a game datetime as an explicit-UTC ISO 8601 string.
+
+    Game datetimes arrive from CFBD in UTC, but SQLite drops the tzinfo, so
+    they come back off the ORM naive. Emitting those bare (``2026-08-30T00:00:00``)
+    makes JavaScript's ``new Date()`` read them as *local* time, which shifts
+    every night kickoff onto the following day. Stamp the UTC offset back on.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
 
 
 # Team Schemas
@@ -194,6 +209,10 @@ class GameBase(BaseModel):
     game_date: Optional[datetime] = Field(None, description="Game date and time")
     game_type: Optional[str] = Field(None, description="Game classification: 'conference_championship', 'bowl', 'playoff', or None for regular season")
     postseason_name: Optional[str] = Field(None, description="Bowl or playoff name (e.g., 'Rose Bowl Game', 'CFP Semifinal')")
+
+    @field_serializer("game_date")
+    def _serialize_game_date(self, dt: Optional[datetime], _info) -> Optional[str]:
+        return iso_utc(dt)
 
 
 class GameCreate(GameBase):

--- a/tests/test_ranking_service.py
+++ b/tests/test_ranking_service.py
@@ -132,7 +132,9 @@ class TestGeneratePredictions:
 
         mock_db.query.return_value = mock_season_query
 
-        predictions = generate_predictions(mock_db, next_week=True, season_year=2025)
+        # No dated games, so prediction falls back to week-number filtering
+        with patch("src.core.ranking_service.next_slate_window", return_value=None):
+            predictions = generate_predictions(mock_db, next_week=True, season_year=2025)
 
         assert predictions == []  # Should return empty list
 

--- a/tests/unit/test_next_slate_window.py
+++ b/tests/unit/test_next_slate_window.py
@@ -1,0 +1,92 @@
+"""Slate windowing: a CFB "week" is not a week, so predictions window by date."""
+
+from datetime import date, datetime
+
+import pytest
+
+from src.core.ranking_service import next_slate_window
+from src.models.models import Game, Team
+from src.models.schemas import iso_utc
+
+
+@pytest.fixture
+def two_teams(db_session):
+    home = Team(name="Home U", conference="P5")
+    away = Team(name="Away U", conference="P5")
+    db_session.add_all([home, away])
+    db_session.commit()
+    return home, away
+
+
+def _game(home, away, when, week):
+    return Game(
+        home_team_id=home.id,
+        away_team_id=away.id,
+        home_score=0,
+        away_score=0,
+        week=week,
+        season=2026,
+        game_date=when,
+        is_processed=False,
+    )
+
+
+@pytest.fixture
+def split_week_one(db_session, two_teams):
+    """CFBD's real 2026 week 1: Aug 29-30, then a gap, then Sep 3-7."""
+    home, away = two_teams
+    days = ["2026-08-29 16:00", "2026-08-30 02:00",
+            "2026-09-03 23:00", "2026-09-04 23:00", "2026-09-05 20:00",
+            "2026-09-06 18:00", "2026-09-07 23:00",
+            "2026-09-11 23:00", "2026-09-12 20:00"]
+    weeks = [1, 1, 1, 1, 1, 1, 1, 2, 2]
+    db_session.add_all(
+        _game(home, away, datetime.strptime(d, "%Y-%m-%d %H:%M"), w)
+        for d, w in zip(days, weeks)
+    )
+    db_session.commit()
+
+
+def test_opening_saturday_is_its_own_slate(db_session, split_week_one):
+    """Week 1 spans nine days; the opener must not drag the Labor Day games in."""
+    week, start, end = next_slate_window(db_session, 2026, today=date(2026, 8, 26))
+    assert week == 1
+    assert start == datetime(2026, 8, 29)
+    assert end == datetime(2026, 8, 31)
+
+
+def test_slate_stays_live_on_its_final_day(db_session, split_week_one):
+    _, start, _ = next_slate_window(db_session, 2026, today=date(2026, 8, 30))
+    assert start == datetime(2026, 8, 29)
+
+
+def test_advances_once_the_slate_is_over(db_session, split_week_one):
+    week, start, end = next_slate_window(db_session, 2026, today=date(2026, 8, 31))
+    assert week == 1
+    assert start == datetime(2026, 9, 3)
+    assert end == datetime(2026, 9, 8)
+
+
+def test_midweek_games_stay_with_their_saturday(db_session, split_week_one):
+    """Week 2 opens Friday — a 2-3 day gap is normal and must not split a slate."""
+    week, start, end = next_slate_window(db_session, 2026, today=date(2026, 9, 8))
+    assert week == 2
+    assert start == datetime(2026, 9, 11)
+    assert end == datetime(2026, 9, 13)
+
+
+def test_none_when_season_is_done(db_session, split_week_one):
+    assert next_slate_window(db_session, 2026, today=date(2027, 1, 1)) is None
+
+
+def test_none_when_nothing_is_dated(db_session, two_teams):
+    home, away = two_teams
+    db_session.add(_game(home, away, None, 1))
+    db_session.commit()
+    assert next_slate_window(db_session, 2026, today=date(2026, 8, 26)) is None
+
+
+def test_iso_utc_marks_naive_datetimes_as_utc():
+    """Bare ISO makes JS read a Saturday night kickoff as Sunday."""
+    assert iso_utc(datetime(2026, 8, 30, 0, 0)) == "2026-08-30T00:00:00+00:00"
+    assert iso_utc(None) is None


### PR DESCRIPTION
Two batches of work on the same branch.

## Projection columns (already on the branch)

- Monte Carlo playoff odds (BID% / CONF% / NAT% / PROJ W) on the rankings board and team pages, read from the cached simulation row for the exact week displayed.
- Prediction table truncated at 15 rows with a show-more toggle — a full week runs 60+ games and buried the bracket.
- Frontend self-checks wired into CI.
- Umami analytics.

## Game dates for the season opener

Week 1 of 2026 runs Aug 29 through Sep 7 — eight games this Saturday, a nine-day gap, then ninety-one over Labor Day weekend. Three bugs made that unreadable.

**Timezone dropped on the wire.** SQLite drops the tzinfo `parse_game_date` sets, so game datetimes come off the ORM naive and we serialized them bare. JS reads an offset-less date-time as *local*, pushing all 121 games that kick off after 8pm ET onto the following day. New `schemas.iso_utc()` stamps the offset back on, used by the `GameBase.game_date` field serializer plus the three routers that hand-roll the field.

**`/api/predictions` stored branch ignored `next_week`** and never emitted `game_date`. The board asked for one week and got all 730 unprocessed games, undated, in arbitrary order.

**"Next week" meant `current_week + 1`**, which with a preseason `current_week` of 1 pointed past the opener at week 2.

Predictions now window by date. `next_slate_window()` walks the season's remaining weeks and splits any week with an internal gap of four days or more, returning `(week, start, end)`. Checked against the real schedule: 2026 week 1 is the only week that splits — every other week tops out at a three-day gap for midweek MACtion, so nothing else changes shape.

`start_new_season.py` seeded `current_week=1`, claiming week 1 was already played. `current_week` tracks the last week *processed*, so a fresh season is week 0 — matching what `seasons.py` already did.

### Effect

`/api/predictions?season=2026` goes from 730 games to the 6 playable openers, dated `2026-08-29T16:00:00+00:00`. (Eight games kick off Saturday; two are FCS matchups, correctly excluded from predictions.)

### Tests

871 pass. New `tests/unit/test_next_slate_window.py` covers the split week, a slate staying live through its final day, advancing once it's over, midweek games not splitting off, the undated fallback, end of season, and `iso_utc`.

### Deploying

Prod needs `python3 scripts/fix_current_week.py --year 2026 --week 0` — the `start_new_season` fix only affects seasons created from here on, so the existing 2026 row still reads 1. The week-0 and week-1 ranking snapshots are byte-identical, so rankings don't move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)