### PR TITLE
Adopt the 2026 CFP selection rule and the rebuilt Pac-12

### DIFF
--- a/src/core/ranking_service.py
+++ b/src/core/ranking_service.py
@@ -1476,19 +1476,24 @@ _QF_BOWLS = ["Rose Bowl", "Sugar Bowl", "Fiesta Bowl", "Peach Bowl"]
 _SF_BOWLS = ["Cotton Bowl", "Orange Bowl"]
 _INDEPENDENT_CONFS = {None, "", "Independent", "Independents", "FBS Independents"}
 
-# CFP format knobs. The 2025-26 format is a 12-team field with five conference
-# champions auto-bid and straight 1-12 seeding by rating. The format is under
-# active revision, so keep these as constants rather than magic numbers.
+# CFP format knobs. The 2026 format is a 12-team field with five auto-bids and
+# straight 1-12 seeding by rating. The format is revised most years, so keep
+# these as constants rather than magic numbers.
 FIELD_SIZE = 12
-# The five highest-ranked conference champions, regardless of tier. There is no
-# reserved Group-of-5 slot: a G5 champion is in only when it out-ranks the other
-# champions, which is how Boise State got in for 2024 and how a G5 champion can
-# be shut out entirely once five P5 conferences are chasing the same five spots.
-CHAMPION_AUTO_BIDS = 5
+# Four of the auto-bids belong to the Power 4 champions outright -- ranking does
+# not enter into it, so a 20th-rated ACC champion is still in. This replaced the
+# 2024-25 rule, where the five *highest-ranked* champions took the auto-bids and
+# a P4 champion could be left out.
+POWER_4_CONFS = frozenset({"ACC", "Big Ten", "Big 12", "SEC"})
+# The fifth goes to the highest-ranked team from the Group of Six -- champion or
+# not, which is new for 2026: a G6 team that loses its title game can still hold
+# the bid. Derived from POWER_4_CONFS rather than listed, so a G6 league that
+# renames or realigns needs no edit here.
+AUTO_BIDS = len(POWER_4_CONFS) + 1
 
 # A conference too small to be a real league does not get a projected champion.
-# ponytail: guards against stale realignment data (the teams table currently
-# lists a 2-team Pac-12); self-corrects once the team importer refreshes.
+# ponytail: guards against stale realignment data -- the teams table sat on a
+# 2-team Pac-12 until the 2026 membership sync. Cheap insurance for the next one.
 MIN_CONFERENCE_SIZE = 4
 
 
@@ -1566,16 +1571,35 @@ def select_cfp_field(rankings: List[dict], champs: List[dict]) -> List[dict]:
     pass dicts carrying team_id / team_name / elo_rating / conference /
     conference_name; `rankings` must already be sorted by rating descending.
 
-    The CHAMPION_AUTO_BIDS highest-rated conference champions take auto-bids, the
-    field fills to FIELD_SIZE with the best remaining teams, and all of them are
-    seeded straight by rating. Tier does not enter into it -- see
-    CHAMPION_AUTO_BIDS.
+    The 2026 rule: the four POWER_4_CONFS champions are in on their titles, the
+    highest-ranked Group of Six team takes the fifth auto-bid whether or not it
+    won its league, Notre Dame is in automatically if it lands in the top
+    FIELD_SIZE, the field fills to FIELD_SIZE with the best remaining teams, and
+    all of them are seeded straight by rating.
     """
     by_rating = lambda c: c["elo_rating"]  # noqa: E731
-    auto = sorted(champs, key=by_rating, reverse=True)[:CHAMPION_AUTO_BIDS]
+    auto = [c for c in champs if c.get("conference_name") in POWER_4_CONFS]
     auto_ids = {c["team_id"] for c in auto}
 
-    field = list(auto)
+    for r in rankings:  # highest-ranked G6 team, champion or not
+        conf = r.get("conference_name")
+        if conf in POWER_4_CONFS or conf in _INDEPENDENT_CONFS or r.get("conference") == "FCS":
+            continue
+        if r["team_id"] not in auto_ids:
+            auto.append(r)
+            auto_ids.add(r["team_id"])
+        break
+
+    # Notre Dame's standing invitation. Only ever bites when the auto-bids push
+    # the at-large cut above the Irish -- otherwise the rating fill takes them
+    # anyway, since our rating order *is* our ranking.
+    for r in rankings[:FIELD_SIZE]:
+        if r["team_name"] == "Notre Dame" and r["team_id"] not in auto_ids:
+            auto.append(r)
+            auto_ids.add(r["team_id"])
+            break
+
+    field = sorted(auto, key=by_rating, reverse=True)[:FIELD_SIZE]
     for r in rankings:  # at-large by rating
         if len(field) >= FIELD_SIZE:
             break

--- a/src/importers/common.py
+++ b/src/importers/common.py
@@ -11,7 +11,10 @@ CONFERENCE_MAP = {
     "Big Ten": ConferenceType.POWER_5,
     "ACC": ConferenceType.POWER_5,
     "Big 12": ConferenceType.POWER_5,
-    "Pac-12": ConferenceType.POWER_5,
+    # The 2026 Pac-12 is a rebuilt Group of Six league (Boise State, Colorado
+    # State, Fresno State, San Diego State, Utah State and Texas State joining
+    # Oregon State and Washington State), not the old power conference.
+    "Pac-12": ConferenceType.GROUP_5,
     "American Athletic": ConferenceType.GROUP_5,
     "Mountain West": ConferenceType.GROUP_5,
     "Conference USA": ConferenceType.GROUP_5,

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -58,7 +58,8 @@ class ConferenceType(str, enum.Enum):
     for ELO calculations and matchup multipliers:
 
     Attributes:
-        POWER_5: Power 5 conferences (SEC, Big Ten, Big 12, ACC, Pac-12)
+        POWER_5: Power conferences (SEC, Big Ten, Big 12, ACC). The rebuilt
+            2026 Pac-12 is Group of Six, not P5.
         GROUP_5: Group of 5 conferences (AAC, C-USA, MAC, MWC, Sun Belt)
         FCS: Football Championship Subdivision (lower division)
 

--- a/tests/integration/test_cfbd_import.py
+++ b/tests/integration/test_cfbd_import.py
@@ -129,17 +129,28 @@ class TestTeamImportWithMock:
         assert boise.conference_name == "Mountain West"
         assert boise.conference == ConferenceType.GROUP_5
 
-        # Boise State leaves for the rebuilt Pac-12, which is a P5 conference.
-        realigned = [dict(t) for t in mock_cfbd_client.get_teams(2026)]
-        for team in realigned:
-            if team["school"] == "Boise State":
-                team["conference"] = "Pac-12"
-        mock_cfbd_client.get_teams.return_value = realigned
+        def realign(school: str, conference: str):
+            teams = [dict(t) for t in mock_cfbd_client.get_teams(2026)]
+            for team in teams:
+                if team["school"] == school:
+                    team["conference"] = conference
+            mock_cfbd_client.get_teams.return_value = teams
 
+        # Boise State leaves for the rebuilt Pac-12, which is a Group of Six
+        # league in 2026 -- the name moves, the tier does not.
+        realign("Boise State", "Pac-12")
         import_teams(mock_cfbd_client, test_db, year=2026)
 
         boise = test_db.query(Team).filter(Team.name == "Boise State").one()
         assert boise.conference_name == "Pac-12"
+        assert boise.conference == ConferenceType.GROUP_5
+
+        # A move up a level has to carry the tier with it.
+        realign("Boise State", "SEC")
+        import_teams(mock_cfbd_client, test_db, year=2027)
+
+        boise = test_db.query(Team).filter(Team.name == "Boise State").one()
+        assert boise.conference_name == "SEC"
         assert boise.conference == ConferenceType.POWER_5
 
     def test_import_teams_calculates_preseason_ratings(self, test_db: Session, mock_cfbd_client):

--- a/tests/unit/test_season_simulation.py
+++ b/tests/unit/test_season_simulation.py
@@ -8,7 +8,8 @@ import pytest
 from src.core import season_simulation as ss
 from src.core.ranking_service import (
     FIELD_SIZE,
-    CHAMPION_AUTO_BIDS,
+    AUTO_BIDS,
+    POWER_4_CONFS,
     RankingService,
     select_cfp_field,
 )
@@ -223,48 +224,62 @@ class TestSelectCfpField:
         rankings = self.make_rankings()
         champs = rankings[:len(CONFERENCES)]
         field = select_cfp_field(rankings, champs)
-        assert sum(t["auto_bid"] for t in field) == CHAMPION_AUTO_BIDS
+        assert sum(t["auto_bid"] for t in field) == AUTO_BIDS
 
-    def _tiny_champ(self, tier="G5"):
+    def _weak_champ(self, conf, team_id=999, name="Weak Champ"):
         return {
-            "team_id": 999,
-            "team_name": "Tiny Champ",
-            "conference": tier,
-            "conference_name": "Mountain West",
+            "team_id": team_id,
+            "team_name": name,
+            "conference": "P5" if conf in POWER_4_CONFS else "G5",
+            "conference_name": conf,
             "elo_rating": 1200.0,  # nowhere near the at-large cut
         }
 
-    def test_weak_champion_rides_an_auto_bid_when_champions_are_scarce(self):
-        """Only five champions exist, so even a terrible one is a top-5 champion."""
+    def test_power_four_champion_is_in_however_badly_rated(self):
+        """The 2026 rule hands the P4 champions their bids outright."""
         rankings = self.make_rankings(n=60)
-        tiny = self._tiny_champ()
-        rankings.append(tiny)
-        power = [r for r in rankings if r["conference"] == "P5"][:4]
+        weak = self._weak_champ("ACC")
+        rankings.append(weak)
 
-        field = select_cfp_field(rankings, power + [tiny])
+        field = select_cfp_field(rankings, [weak])
 
         assert next(t for t in field if t["team_id"] == 999)["auto_bid"] is True
 
-    def test_sixth_ranked_champion_is_shut_out(self):
-        """Auto-bids go to the five best champions, not one per tier.
-
-        The old rule reserved a slot for the highest-rated G5 champion, which
-        would drag this team in over a better-rated P5 champion. The real CFP
-        rule has no reserved slot: with five P5 conferences chasing five spots,
-        a G5 champion can miss entirely.
-        """
+    def test_group_of_six_bid_follows_the_ranking_not_the_title(self):
+        """The fifth bid is the best-ranked G6 team, champion or not."""
         rankings = self.make_rankings(n=60)
-        tiny = self._tiny_champ()
-        rankings.append(tiny)
-        power = [r for r in rankings if r["conference"] == "P5"][:5]
-        assert len(power) == 5, "need five P5 champions to crowd the G5 out"
+        weak = self._weak_champ("Mountain West")
+        rankings.append(weak)
+        power = [r for r in rankings if r["conference_name"] in POWER_4_CONFS][:4]
+        best_g6 = next(r for r in rankings if r["conference_name"] not in POWER_4_CONFS)
+        assert best_g6["team_id"] != weak["team_id"]
 
-        field = select_cfp_field(rankings, power + [tiny])
+        field = select_cfp_field(rankings, power + [weak])
 
         auto_ids = {t["team_id"] for t in field if t["auto_bid"]}
-        assert 999 not in auto_ids
-        assert auto_ids == {c["team_id"] for c in power}
-        assert sum(t["auto_bid"] for t in field) == CHAMPION_AUTO_BIDS
+        assert auto_ids == {c["team_id"] for c in power} | {best_g6["team_id"]}
+        assert 999 not in {t["team_id"] for t in field}
+
+    def test_notre_dame_is_automatic_inside_the_top_twelve(self):
+        """Weak auto-bids push the at-large cut above the Irish; they are in anyway."""
+        rankings = self.make_rankings(n=60)
+        irish = {
+            "team_id": 500, "team_name": "Notre Dame", "conference": "P5",
+            "conference_name": "FBS Independents",
+            "elo_rating": rankings[9]["elo_rating"] - 5,  # ranked 11th
+        }
+        rankings.insert(10, irish)
+        champs = [self._weak_champ(c, team_id=900 + i, name=f"{c} champ")
+                  for i, c in enumerate(sorted(POWER_4_CONFS))]
+        rankings.extend(champs)
+        rankings.sort(key=lambda r: r["elo_rating"], reverse=True)
+        assert rankings.index(irish) < FIELD_SIZE
+
+        field = select_cfp_field(rankings, champs)
+
+        irish_seed = next(t for t in field if t["team_id"] == 500)
+        assert irish_seed["auto_bid"] is True
+        assert len(field) == FIELD_SIZE
 
 
 class TestSimulateSeason:
@@ -341,7 +356,7 @@ class TestBuildProjection:
         assert projection["runs"] == 30
         assert len(projection["field"]) == FIELD_SIZE
         assert [t["seed"] for t in projection["field"]] == list(range(1, FIELD_SIZE + 1))
-        assert sum(t["auto_bid"] for t in projection["field"]) == CHAMPION_AUTO_BIDS
+        assert sum(t["auto_bid"] for t in projection["field"]) == AUTO_BIDS
 
         # Probabilities are present and sane.
         for t in projection["field"]:

--- a/utilities/sync_conferences.py
+++ b/utilities/sync_conferences.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Sync team conference membership with CFBD for a season.
+
+Realignment moves teams between conferences and promotes FCS schools into FBS.
+The full team import (``import_real_data.py``) does the same thing, but it also
+rewrites every preseason factor and is not something you want to run once the
+season is underway. This does the membership half only.
+
+Usage:
+    python utilities/sync_conferences.py --season 2026            # dry run
+    python utilities/sync_conferences.py --season 2026 --apply
+
+Promoted teams (FCS in our table, FBS in CFBD's list) get a fresh preseason
+rating, since an FCS rating is not on the same scale as an FBS one.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from src.core.ranking_service import RankingService
+from src.importers.teams import conference_tier
+from src.integrations.cfbd_client import CFBDClient
+from src.models.database import SessionLocal
+from src.models.models import Team
+
+
+def sync(db, season: int, apply: bool) -> int:
+    teams_data = CFBDClient().get_teams(season)
+    if not teams_data:
+        print("✗ CFBD returned no teams")
+        return 1
+
+    ranking_service = RankingService(db)
+    moved, promoted, unknown = [], [], []
+
+    for team_data in teams_data:
+        name = team_data["school"]
+        conference_name = team_data.get("conference", "FBS Independents")
+        tier = conference_tier(name, conference_name)
+
+        team = db.query(Team).filter(Team.name == name).first()
+        if team is None:
+            unknown.append(f"{name} ({conference_name})")
+            continue
+
+        if team.is_fcs:
+            promoted.append(f"{name}: FCS -> {conference_name}")
+            team.is_fcs = False
+        elif team.conference_name != conference_name or team.conference != tier:
+            moved.append(f"{name}: {team.conference_name} -> {conference_name} ({tier.value})")
+
+        team.conference_name = conference_name
+        team.conference = tier
+
+    for label, rows in (("Realigned", moved), ("Promoted to FBS", promoted)):
+        print(f"\n{label}: {len(rows)}")
+        for row in rows:
+            print(f"  {row}")
+    if unknown:
+        print(f"\nNot in our teams table ({len(unknown)}) -- run the full import to add them:")
+        for row in unknown:
+            print(f"  {row}")
+
+    if not apply:
+        db.rollback()
+        print("\nDry run, nothing written. Re-run with --apply.")
+        return 0
+
+    # Promoted teams keep their FCS-scale rating until it is recomputed. `season`
+    # is deliberately not passed: the previous-season blend would drag an FCS
+    # rating (where ~1060 is a *good* team) onto the FBS scale and land them
+    # hundreds of points below the weakest real FBS team. The formula alone errs
+    # the other way -- no recruiting or portal data means a default-ish 1500, a
+    # median FBS team -- so cap a newcomer at the weakest established FBS team.
+    # ponytail: one flat floor, so a perennial FCS champion starts level with a
+    # first-timer. Results move them apart inside a month; revisit only if the
+    # early-season predictions for these teams are visibly bad.
+    promoted_names = [row.split(":")[0] for row in promoted]
+    floor = min(
+        elo for elo, in db.query(Team.elo_rating)
+        .filter(Team.is_fcs == False, Team.name.notin_(promoted_names))  # noqa: E712
+        .all()
+    )
+    for name in promoted_names:
+        team = db.query(Team).filter(Team.name == name).one()
+        before = team.elo_rating
+        ranking_service.initialize_team_rating(team)
+        if team.elo_rating > floor:
+            team.elo_rating = team.initial_rating = floor
+        print(f"  Rated {team.name}: {before:.0f} -> {team.elo_rating:.0f} (FBS floor {floor:.0f})")
+
+    db.commit()
+    print(f"\n✓ Wrote {len(moved)} realignments and {len(promoted)} promotions for {season}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--season", type=int, required=True)
+    parser.add_argument("--apply", action="store_true", help="write changes (default: dry run)")
+    args = parser.parse_args()
+
+    db = SessionLocal()
+    try:
+        return sync(db, args.season, args.apply)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The CFP format changed for 2026 and our conference table had drifted a full realignment cycle behind. Both are fixed here, along with the tooling to keep membership current next August.

## Selection rule

Still twelve teams seeded straight by rating. What changed:

- ACC, Big Ten, Big 12 and SEC champions take four auto-bids outright — ranking is irrelevant, so a 20th-rated ACC champion is in.
- The fifth bid goes to the highest-ranked Group of Six team, **champion or not**. A G6 team that loses its title game can still hold the bid.
- Notre Dame is automatic inside the top twelve. Only bites when the auto-bids push the at-large cut above the Irish.

The old rule gave all five bids to the highest-ranked champions, which could shut out a P4 champion and gave a G6 team nothing without a title. `CHAMPION_AUTO_BIDS` becomes `AUTO_BIDS` (4 + 1); the G6 set is derived from `POWER_4_CONFS` rather than listed, so a G6 rename needs no edit.

## Pac-12 tier

The rebuilt Pac-12 is Group of Six, not a power conference. The tier drives the P5-over-G5 ELO multiplier, and under the new rule it also decides eligibility for the fifth auto-bid — a Pac-12 team tagged P5 would have been locked out of the slot it is most likely to win.

## Membership

`utilities/sync_conferences.py` syncs conference membership from CFBD without the full team import, which rewrites every preseason factor and is not safe to run mid-season. Dry-run by default.

Applied to the local DB: 12 realignments, 3 promotions, 138 FBS teams matching CFBD exactly. Promoted teams (North Dakota State, Sacramento State, Missouri State) are capped at the weakest established FBS rating — their FCS rating is on a different scale, and blending it forward put them at 829-901, hundreds of points below any real FBS team. Flat floor, marked `ponytail:`; results separate them within a month.

## Verification

919 tests pass. Re-ran the 10k simulation: Toledo now holds seed 12 on the G6 auto-bid, which is the new rule firing visibly.

`test_reimport_moves_realigned_teams` asserted Pac-12 was P5. It now checks that the name moves without a tier change, then that a move up a level does carry the tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)