### PR TITLE
fix: daily score pulls, and stop crowning winners of unplayed games

### DIFF
--- a/docs/SEASON-RUNBOOK.md
+++ b/docs/SEASON-RUNBOOK.md
@@ -207,16 +207,30 @@ If predictions return an empty list, confirm games are in the DB and the season 
 
 ---
 
-## 3. Weekly Update (every Monday after games)
+## 3. Weekly Update (daily during the season)
 
-### Automated cron (runs at 9 AM every Monday)
+### Automated cron (runs at 6 AM daily)
 
 **Cron is the one scheduler.** Install under the crontab of the user that owns
 the deployment:
 
 ```
-0 9 * * 1 /var/www/cfb-rankings/utilities/weekly_update.sh >> /var/log/cfb-rankings/weekly.log 2>&1
+0 6 * * * /var/www/cfb-rankings/utilities/weekly_update.sh >> /var/log/cfb-rankings/weekly.log 2>&1
 ```
+
+6 AM clears the late Pacific kickoffs that finish around 1–2 AM Eastern, so
+Saturday's scores are on the site by Sunday breakfast rather than Monday
+morning. The times above are **server local time** — check with `timedatectl`
+and shift to `0 10 * * *` if the box runs UTC.
+
+Daily is safe and cheap. The import updates games in place rather than
+duplicating them, the ELO step only picks up `is_processed = 0`, and
+`save_weekly_rankings()` deletes and rewrites the week it snapshots — so a
+Sunday run that catches a week mid-flight is corrected by Monday's. One run
+costs roughly 40 CFBD calls against a 30,000/month limit.
+
+Success notifications only fire when games were actually processed; failures
+always notify.
 
 The script:
 1. Loads `CFBD_API_KEY` from `.env` if not already set
@@ -259,10 +273,16 @@ To stop it recurring, move the entry to www-data's crontab
 ### Run the weekly update manually (if cron fails or needs re-running)
 
 ```bash
-cd /var/www/cfb-rankings
-export CFBD_API_KEY=<your-key>
-bash utilities/weekly_update.sh
+sudo -u www-data bash /var/www/cfb-rankings/utilities/weekly_update.sh
+sudo systemctl restart cfb-rankings   # step 4 warns if www-data lacks sudo
 ```
+
+No `CFBD_API_KEY` export needed: the script sources
+`/var/www/cfb-rankings/.env` itself, which is also why the cron entry carries
+no key. It has to run **as `www-data`** to do that — `.env` is mode 600 and
+owned by `www-data`, so running it as your own user fails with
+`grep: /var/www/cfb-rankings/.env: Permission denied` followed by
+`✗ ERROR: CFBD_API_KEY not set`. Same reason the crontab belongs to `www-data`.
 
 ### Check the weekly log
 
@@ -310,7 +330,6 @@ specific week without running the full pipeline.
 
 ```bash
 cd /var/www/cfb-rankings
-export CFBD_API_KEY=<your-key>
 sudo -u www-data venv/bin/python3 import_real_data.py --season 2026 --max-week 8
 ```
 
@@ -361,7 +380,6 @@ Bowl games use a separate postseason import path inside `import_real_data.py`
 
 ```bash
 cd /var/www/cfb-rankings
-export CFBD_API_KEY=<your-key>
 sudo -u www-data venv/bin/python3 import_real_data.py --season 2026
 ```
 
@@ -556,7 +574,7 @@ EOF
 2. Re-import scores and reprocess:
 
 ```bash
-export CFBD_API_KEY=<your-key>
+cd /var/www/cfb-rankings
 sudo -u www-data venv/bin/python3 import_real_data.py --season 2026
 bash utilities/weekly_update.sh
 ```

--- a/frontend/games.html
+++ b/frontend/games.html
@@ -225,8 +225,9 @@
       ).forEach(game => {
         const row = document.createElement('tr');
 
-        // Check if game has been played (scores exist)
-        const hasScore = game.home_score !== null && game.away_score !== null;
+        // Check if game has been played (see isPlayed in date-utils.js —
+        // scheduled games carry placeholder 0-0 scores, not nulls).
+        const hasScore = isPlayed(game);
 
         if (hasScore) {
           // Completed game - display winner/loser

--- a/frontend/js/date-utils.js
+++ b/frontend/js/date-utils.js
@@ -138,3 +138,33 @@ function formatGameDateMobile(dateString) {
     return 'TBD';
   }
 }
+
+/**
+ * Has this game actually been played?
+ *
+ * The importer stores scheduled games with placeholder 0-0 scores rather than
+ * nulls, so a null check alone reports a future game as final — and 0 > 0 is
+ * false, which silently crowns the away team as winner. This mirrors the rule
+ * RankingService.process_game() uses to reject a future game.
+ *
+ * @param {{home_score: ?number, away_score: ?number}} game - Game from the API
+ * @returns {boolean} True if the game has a real result
+ *
+ * @example
+ * isPlayed({home_score: 15, away_score: 10})  // true
+ * isPlayed({home_score: 0, away_score: 0})    // false — scheduled
+ * isPlayed({home_score: null, away_score: 3}) // false
+ */
+function isPlayed(game) {
+  if (!game) return false;
+  if (game.home_score === null || game.home_score === undefined) return false;
+  if (game.away_score === null || game.away_score === undefined) return false;
+  // ponytail: a real 0-0 final does not happen in modern CFB. Switch to
+  // is_processed if the sport ever produces one.
+  return !(game.home_score === 0 && game.away_score === 0);
+}
+
+// Expose the pure helpers so the node self-checks can exercise them.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { formatGameDate, formatGameDateMobile, isPlayed };
+}

--- a/tests/frontend/test_game_status.js
+++ b/tests/frontend/test_game_status.js
@@ -1,0 +1,28 @@
+// Self-check for isPlayed, the played/scheduled split on the games table.
+//   node tests/frontend/test_game_status.js
+//
+// The bug this guards: scheduled games arrive with placeholder 0-0 scores, so a
+// null-only check sent them down the results branch, where `home > away` is
+// false and the away team was rendered as the winner of a game nobody played.
+
+const assert = require('assert');
+const { isPlayed } = require('../../frontend/js/date-utils.js');
+
+// A real result is played, whichever side won.
+assert.strictEqual(isPlayed({ home_score: 15, away_score: 10 }), true, 'home win is played');
+assert.strictEqual(isPlayed({ home_score: 10, away_score: 15 }), true, 'away win is played');
+
+// The regression: placeholder 0-0 is a scheduled game, not a tie.
+assert.strictEqual(isPlayed({ home_score: 0, away_score: 0 }), false, '0-0 placeholder is scheduled');
+
+// A shutout still counts — only BOTH sides at zero means unplayed.
+assert.strictEqual(isPlayed({ home_score: 33, away_score: 0 }), true, 'home shutout is played');
+assert.strictEqual(isPlayed({ home_score: 0, away_score: 33 }), true, 'away shutout is played');
+
+// Missing scores in any form are not a result.
+assert.strictEqual(isPlayed({ home_score: null, away_score: 3 }), false, 'null home score');
+assert.strictEqual(isPlayed({ home_score: 3, away_score: null }), false, 'null away score');
+assert.strictEqual(isPlayed({}), false, 'undefined scores');
+assert.strictEqual(isPlayed(null), false, 'no game at all');
+
+console.log('✓ test_game_status.js — all assertions passed');

--- a/utilities/weekly_update.sh
+++ b/utilities/weekly_update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # EPIC-033 Story 33.3 / EPIC-035: Automated Weekly Update with Monitoring
 #
-# Runs every Monday morning via cron to:
+# Runs daily via cron during the season to:
 #   1. Pull the latest game schedule from CFBD (with retry logic)
 #   2. Import completed game results (3 attempts, exponential backoff)
 #   3. Process results through the ELO algorithm
@@ -10,8 +10,12 @@
 #   6. Restart the API service
 #   7. Send Slack / email notification with result summary
 #
-# Cron entry (run as bdailey, 9am every Monday):
-#   0 9 * * 1 /var/www/cfb-rankings/utilities/weekly_update.sh >> /var/log/cfb-rankings/weekly.log 2>&1
+# Cron entry (run as the user that owns the deployment, 6am daily):
+#   0 6 * * * /var/www/cfb-rankings/utilities/weekly_update.sh >> /var/log/cfb-rankings/weekly.log 2>&1
+#
+# Re-running is safe: the import updates games in place, the ELO step only picks
+# up is_processed=0, and save_weekly_rankings() rewrites the week's snapshot.
+# A day with no finished games costs ~40 CFBD calls and changes nothing.
 #
 # Logs:    /var/log/cfb-rankings/weekly.log
 # Env vars required:
@@ -338,7 +342,7 @@ echo ""
 echo "[4/4] Restarting cfb-rankings service..."
 if [ "${SKIP_SERVICE_RESTART:-0}" = "1" ]; then
     echo "⚠ Skipping service restart (called via API — restart not needed)"
-elif sudo systemctl restart cfb-rankings 2>/dev/null; then
+elif sudo -n systemctl restart cfb-rankings 2>/dev/null; then
     echo "✓ Service restarted"
 else
     echo "⚠ Could not restart service (may need sudo permissions — restart manually)"
@@ -349,7 +353,13 @@ NOTIFY_BODY="Season $SEASON | Processed: $GAMES_PROCESSED games | Snapshots: $SN
 if [ -n "$DIFF_TEXT" ]; then
     NOTIFY_BODY="$NOTIFY_BODY\n\nBig movers (5+ spots):\n$DIFF_TEXT"
 fi
-_send_notification "✅ Weekly update complete ($SEASON)" "$NOTIFY_BODY"
+# ponytail: on a daily cron most runs process nothing — notifying every time
+# trains people to ignore the channel. Failures notify unconditionally above.
+if [ "$GAMES_PROCESSED" -gt 0 ]; then
+    _send_notification "✅ Weekly update complete ($SEASON)" "$NOTIFY_BODY"
+else
+    echo "No new games — skipping success notification"
+fi
 
 # ── Write final import log ─────────────────────────────────────────────────────
 "$PYTHON" - <<EOF
@@ -364,7 +374,7 @@ else:
     log_data = {}
 
 log_data.update({
-    "last_run": datetime.datetime.utcnow().isoformat() + "Z",
+    "last_run": datetime.datetime.now(datetime.UTC).isoformat(),
     "season": $SEASON,
     "games_processed": $GAMES_PROCESSED,
     "status": "success",


### PR DESCRIPTION
Two fixes found while chasing why Saturday's games were not on the site Sunday.

## Daily score pulls

Cron ran once a week, Monday 9am — a cadence chosen back when the site did not
display individual game scores. It does now, so results sat unpublished for a
day and a half every week.

- Cron moves to `0 6 * * *`. 6am clears the late Pacific kickoffs that finish
  around 1–2am Eastern.
- Success notification now fires only when games were actually processed; on a
  daily cron most runs process nothing. Failures still notify.
- `sudo -n` on the service restart, so an unprivileged run fails fast instead of
  hanging on a password prompt with no tty.
- Runbook: manual runs need `sudo -u www-data` (`.env` is 600 www-data). Removed
  four `CFBD_API_KEY` exports that never had any effect — `import_real_data.py`
  calls `load_dotenv()`, and `sudo -u` strips the exported var regardless.

Re-running daily is safe and cheap: the import updates games in place, the ELO
step only picks up `is_processed = 0`, `save_weekly_rankings()` deletes and
rewrites the week it snapshots, and a run costs ~40 CFBD calls against a
30,000/month limit.

## Unplayed games showed a winner

The schedule page listed `Fordham 0-0 North Dakota State` as a Fordham win for a
game that has not kicked off. Scheduled games carry placeholder `0-0` scores
rather than nulls, so the null check treated them as final — and `home > away`
is false at 0-0, handing every unplayed row to the away team.

Extracted `isPlayed()` into `date-utils.js` (same 0-0 rule the backend uses to
reject a future game) with a node self-check. Shutouts stay played; only both
sides at zero means unplayed.

## Verification

`node tests/frontend/test_game_status.js` and `test_countdown.js` pass locally;
CI globs `tests/frontend/*.js` so the new check runs there too. The daily import
itself already ran by hand on the VPS — Week 1 results and the movers report
landed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BDjuteCs2RZtzL5dZY7S9